### PR TITLE
fixed: Duplicate embed delete prompt when same note has multiple embeds

### DIFF
--- a/src/components/dom-components/modals/remove-embed-modal/remove-embed-modal.ts
+++ b/src/components/dom-components/modals/remove-embed-modal/remove-embed-modal.ts
@@ -1,7 +1,10 @@
 import '../migration-modal/migration-modal.scss';
 import { Modal, TFile } from 'obsidian';
 import InkPlugin from 'src/main';
-import { findNotesContainingFileEmbed } from 'src/logic/utils/convert-file-embeds';
+import {
+	countFileEmbedOccurrencesInVault,
+	findNotesContainingFileEmbed,
+} from 'src/logic/utils/convert-file-embeds';
 
 ////////
 ////////
@@ -28,6 +31,7 @@ export class RemoveEmbedModal extends Modal {
 
 	private phase: Phase = Phase.Scanning;
 	private affectedNotes: TFile[] = [];
+	private totalEmbedCount = 0;
 
 	private progressBarInnerEl: HTMLElement | null = null;
 	private statusTextEl: HTMLElement | null = null;
@@ -79,16 +83,28 @@ export class RemoveEmbedModal extends Modal {
 
 	private async runScan() {
 		try {
+			const vault = this.plugin.app.vault;
 			this.affectedNotes = await findNotesContainingFileEmbed(
-				this.plugin.app.vault,
+				vault,
 				this.embeddedFile.path,
 				this.embedType,
 				(scanned, total) => {
 					const remaining = total - scanned;
-					const pct = total > 0 ? (scanned / total) * 100 : 100;
+					const pct = total > 0 ? (scanned / total) * 100 : 50;
 					if (this.progressBarInnerEl) this.progressBarInnerEl.style.width = pct.toFixed(1) + '%';
 					if (this.remainingCountEl) this.remainingCountEl.setText(String(remaining));
 					if (this.foundCountEl) this.foundCountEl.setText(String(this.affectedNotes.length));
+				},
+			);
+			this.totalEmbedCount = await countFileEmbedOccurrencesInVault(
+				vault,
+				this.embeddedFile.path,
+				this.embedType,
+				(scanned, total) => {
+					const remaining = total - scanned;
+					const pct = total > 0 ? 50 + (scanned / total) * 50 : 100;
+					if (this.progressBarInnerEl) this.progressBarInnerEl.style.width = pct.toFixed(1) + '%';
+					if (this.remainingCountEl) this.remainingCountEl.setText(String(remaining));
 				},
 			);
 		} catch (err) {
@@ -96,12 +112,13 @@ export class RemoveEmbedModal extends Modal {
 			return;
 		}
 
+		const isOnlyEmbedInVault = this.totalEmbedCount === 1;
 		const isOnlyInCurrentNote = this.affectedNotes.length === 1;
 
-		if (isOnlyInCurrentNote) {
+		if (isOnlyEmbedInVault && isOnlyInCurrentNote) {
 			this.renderConfirmPhase();
 		} else {
-			// File is embedded elsewhere; remove embed only without prompting
+			// Other notes or duplicate embeds in this note still reference the file.
 			this.opts.onRemoveEmbedOnly();
 			this.close();
 		}

--- a/src/logic/utils/convert-file-embeds.ts
+++ b/src/logic/utils/convert-file-embeds.ts
@@ -58,6 +58,57 @@ export type FileConversionResult = {
 
 ////////
 
+function buildFileEmbedPattern(
+	svgFilePath: string,
+	embedType: 'inkWriting' | 'inkDrawing',
+	global = false,
+): RegExp {
+	const escapedPath = svgFilePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	const altText = embedType === 'inkWriting' ? 'InkWriting' : 'InkDrawing';
+	return new RegExp(
+		` !\\[${altText}\\]\\(<${escapedPath}>\\)`,
+		global ? 'g' : undefined,
+	);
+}
+
+/** Counts v2 embed lines for one file in a single markdown string. */
+export function countFileEmbedOccurrencesInMarkdown(
+	markdownContent: string,
+	svgFilePath: string,
+	embedType: 'inkWriting' | 'inkDrawing',
+): number {
+	const pattern = buildFileEmbedPattern(svgFilePath, embedType, true);
+	return markdownContent.match(pattern)?.length ?? 0;
+}
+
+/**
+ * Counts every v2 embed line in the vault that references the given file.
+ * Used when deciding whether deleting one embed can also delete the attachment.
+ */
+export async function countFileEmbedOccurrencesInVault(
+	vault: Vault,
+	svgFilePath: string,
+	embedType: 'inkWriting' | 'inkDrawing',
+	onProgress?: (scanned: number, total: number) => void,
+): Promise<number> {
+	const mdFiles = vault.getMarkdownFiles();
+	const total = mdFiles.length;
+	let embedCount = 0;
+
+	for (let i = 0; i < mdFiles.length; i++) {
+		const file = mdFiles[i];
+		try {
+			const content = await vault.cachedRead(file);
+			embedCount += countFileEmbedOccurrencesInMarkdown(content, svgFilePath, embedType);
+		} catch (_) {
+			// Unreadable file – skip
+		}
+		onProgress?.(i + 1, total);
+	}
+
+	return embedCount;
+}
+
 /**
  * Scans the vault for markdown files that contain a v2 embed referencing the
  * given SVG file path with the given embed type.
@@ -73,14 +124,7 @@ export async function findNotesContainingFileEmbed(
 	const mdFiles = vault.getMarkdownFiles();
 	const total = mdFiles.length;
 	const results: TFile[] = [];
-
-	// Escape path for use inside a regex
-	const escapedPath = svgFilePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-	// Match the specific image alt depending on type
-	const altText = fromType === 'inkWriting' ? 'InkWriting' : 'InkDrawing';
-	const pattern = new RegExp(
-		` !\\[${altText}\\]\\(<${escapedPath}>\\)`,
-	);
+	const pattern = buildFileEmbedPattern(svgFilePath, fromType);
 
 	for (let i = 0; i < mdFiles.length; i++) {
 		const file = mdFiles[i];

--- a/tests/components/dom-components/modals/remove-embed-modal/remove-embed-modal.test.ts
+++ b/tests/components/dom-components/modals/remove-embed-modal/remove-embed-modal.test.ts
@@ -4,10 +4,11 @@
 
 import { TFile } from 'obsidian';
 import { RemoveEmbedModal } from 'src/components/dom-components/modals/remove-embed-modal/remove-embed-modal';
-import { findNotesContainingFileEmbed } from 'src/logic/utils/convert-file-embeds';
+import { findNotesContainingFileEmbed, countFileEmbedOccurrencesInVault } from 'src/logic/utils/convert-file-embeds';
 
 jest.mock('src/logic/utils/convert-file-embeds', () => ({
 	findNotesContainingFileEmbed: jest.fn(),
+	countFileEmbedOccurrencesInVault: jest.fn(),
 }));
 
 function makePlugin() {
@@ -25,6 +26,7 @@ describe('RemoveEmbedModal', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+		(countFileEmbedOccurrencesInVault as jest.Mock).mockResolvedValue(1);
 	});
 
 	describe('scan phase', () => {
@@ -76,8 +78,9 @@ describe('RemoveEmbedModal', () => {
 	});
 
 	describe('when notes.length === 1', () => {
-		it('does not call onRemoveEmbedOnly immediately (shows confirm phase instead)', async () => {
+		it('does not call onRemoveEmbedOnly immediately when only one embed exists (shows confirm phase instead)', async () => {
 			(findNotesContainingFileEmbed as jest.Mock).mockResolvedValueOnce([sourceMdFile]);
+			(countFileEmbedOccurrencesInVault as jest.Mock).mockResolvedValueOnce(1);
 
 			const plugin = makePlugin();
 			const onRemoveEmbedOnly = jest.fn();
@@ -95,6 +98,29 @@ describe('RemoveEmbedModal', () => {
 			// Unlike notes.length > 1, we show confirm phase — callbacks not invoked yet
 			expect(onRemoveEmbedOnly).not.toHaveBeenCalled();
 			expect(onRemoveEmbedAndFile).not.toHaveBeenCalled();
+		});
+
+		it('calls onRemoveEmbedOnly when the same note embeds the file more than once', async () => {
+			(findNotesContainingFileEmbed as jest.Mock).mockResolvedValueOnce([sourceMdFile]);
+			(countFileEmbedOccurrencesInVault as jest.Mock).mockResolvedValueOnce(2);
+
+			const plugin = makePlugin();
+			const onRemoveEmbedOnly = jest.fn();
+			const onRemoveEmbedAndFile = jest.fn();
+			const modal = new RemoveEmbedModal(plugin, embeddedFile, 'inkWriting', {
+				sourceMdFile,
+				onRemoveEmbedOnly,
+				onRemoveEmbedAndFile,
+			});
+			modal.close = jest.fn();
+
+			modal.onOpen();
+
+			await new Promise((r) => setTimeout(r, 0));
+
+			expect(onRemoveEmbedOnly).toHaveBeenCalledTimes(1);
+			expect(onRemoveEmbedAndFile).not.toHaveBeenCalled();
+			expect(modal.close).toHaveBeenCalled();
 		});
 
 		it('Cancel closes modal', async () => {

--- a/tests/logic/utils/ConvertFileEmbeds.test.ts
+++ b/tests/logic/utils/ConvertFileEmbeds.test.ts
@@ -21,6 +21,8 @@ jest.mock('src/components/formats/current/utils/duplicate-files', () => ({
 import { TFile } from 'obsidian';
 import {
 	FILE_CONVERSION_IN_PLACE,
+	countFileEmbedOccurrencesInMarkdown,
+	countFileEmbedOccurrencesInVault,
 	findNotesContainingFileEmbed,
 	removeAllEmbedsOfFileFromNote,
 	updateEmbedInNote,
@@ -181,6 +183,40 @@ describe('findNotesContainingFileEmbed', () => {
 		);
 		expect(results).toHaveLength(1);
 		expect(results[0].path).toBe('Notes/Good.md');
+	});
+});
+
+// ─── countFileEmbedOccurrencesInMarkdown / countFileEmbedOccurrencesInVault ───
+
+describe('countFileEmbedOccurrencesInMarkdown', () => {
+	const WRITING_PATH = 'Ink/Writing/my-note.svg';
+
+	it('counts multiple embeds of the same file in one note', () => {
+		const markdown = `# Note\n\n${writingLine(WRITING_PATH)}\nMore\n${writingLine(WRITING_PATH)}\n`;
+		expect(countFileEmbedOccurrencesInMarkdown(markdown, WRITING_PATH, 'inkWriting')).toBe(2);
+	});
+
+	it('returns zero when the file is not embedded', () => {
+		const markdown = `# Note\n\n${writingLine('Ink/Writing/other.svg')}\n`;
+		expect(countFileEmbedOccurrencesInMarkdown(markdown, WRITING_PATH, 'inkWriting')).toBe(0);
+	});
+});
+
+describe('countFileEmbedOccurrencesInVault', () => {
+	const WRITING_PATH = 'Ink/Writing/my-note.svg';
+
+	it('sums embed counts across all markdown files', async () => {
+		const vault = makeVault({
+			'Notes/A.md': `# A\n\n${writingLine(WRITING_PATH)}\n${writingLine(WRITING_PATH)}\n`,
+			'Notes/B.md': `# B\n\n${writingLine(WRITING_PATH)}\n`,
+			'Notes/C.md': `# C\n\n`,
+		});
+		const count = await countFileEmbedOccurrencesInVault(
+			vault as any,
+			WRITING_PATH,
+			'inkWriting',
+		);
+		expect(count).toBe(3);
 	});
 });
 


### PR DESCRIPTION
## Summary

- Counted vault-wide embed references before offering to delete an ink attachment during remove-embed.
- When the same note embeds a file more than once, deleting one embed now removes only that embed instead of prompting to delete the source file.

## ClickUp

- [Fix deleting source file issue](https://app.clickup.com/t/86d3dphqb) - `86d3dphqb`

## Test plan

- [x] `npm run test:unit -- --testPathPattern="remove-embed-modal|ConvertFileEmbeds"`
- [x] `npm run build`

## Stack

Base: `release_0.5`
Depends on: none

Made with [Cursor](https://cursor.com)