### PR TITLE
added: Migrate legacy Ink files on open from editor notice

### DIFF
--- a/docs/file-format-and-conversion.md
+++ b/docs/file-format-and-conversion.md
@@ -80,6 +80,7 @@ flowchart LR
 - Strokes that were in the legacy editor **stash** at last save are not in the v1 JSON and cannot be recovered (same limitation as before).
 - If the target `.svg` already exists, the file step is skipped but notes may still be updated.
 - Open **Settings → Ink → Update Ink files…** or run the command **Migrate legacy ink embeds to ink-canvas**.
+- For migrating a **single** file from the editor notice (embed vs dedicated reopen rules), see [legacy-migrate-on-open.md](./legacy-migrate-on-open.md).
 
 ## Drawing ↔ writing conversion
 

--- a/docs/legacy-migrate-on-open.md
+++ b/docs/legacy-migrate-on-open.md
@@ -4,10 +4,14 @@
 
 ## Conceptual understanding
 
-When a writing or drawing editor loads a legacy file (v1 `.writing` / `.drawing`, or an SVG that still stores tldraw metadata), Ink shows a persistent notice with **Migrate to new format**. That action permanently converts only the opened attachment, refreshes Live Preview embeds that reference it, and then either:
+When a writing or drawing editor loads a legacy file (v1 `.writing` / `.drawing`, or an SVG that still stores tldraw metadata), Ink shows a persistent notice with **Migrate to new format**. Only **one** notice is kept open per attachment path: showing another for the same file replaces the previous CTA.
+
+That migrate action permanently converts only the opened attachment, refreshes Live Preview embeds that reference it, and then either:
 
 - **stays on the markdown note** if migration started from an **embed**, or
 - **opens the converted SVG in a dedicated ink view** if migration started from a **dedicated** writing/drawing leaf.
+
+Expanding an unlocked embed to a dedicated view **dismisses** any migrate notice for that file first (expand also `saveAndHalt`s, which can already rewrite a tldraw SVG as ink-canvas on disk).
 
 Bulk vault migration (Settings / command palette) remains a separate path; see [file-format-and-conversion.md](./file-format-and-conversion.md).
 
@@ -16,17 +20,21 @@ Bulk vault migration (Settings / command palette) remains a separate path; see [
 ```mermaid
 flowchart TD
   Open["Open legacy writing or drawing editor"]
-  Notice["Show Legacy Ink file notice"]
+  Notice["Show or replace notice for this file path"]
+  Expand["Expand embed to dedicated"]
+  DismissExpand["dismissLegacyInkNoticesForFile"]
+  SaveHalt["saveAndHalt then open dedicated leaf"]
   Migrate["migrateLegacyInkFileOnOpen"]
   Refresh["refreshLivePreviewEmbedsWhenReady"]
+  ClearNotice["dismissLegacyInkNoticesForFile"]
   Embed{"isEmbedded?"}
   Stay["Stay on markdown note"]
   Dedicated["openInkFileInView for new SVG"]
 
   Open --> Notice
+  Expand --> DismissExpand --> SaveHalt
   Notice -->|"Migrate to new format"| Migrate
-  Migrate --> Refresh
-  Refresh --> Embed
+  Migrate --> Refresh --> ClearNotice --> Embed
   Embed -->|yes| Stay
   Embed -->|no| Dedicated
 ```
@@ -37,7 +45,8 @@ Editors pass `isEmbedded` from their existing `embedded` prop into `showLegacyIn
 
 | Piece | Role |
 |-------|------|
-| [`legacy-ink-notice.ts`](../src/logic/utils/legacy-ink-notice.ts) | Notice UI; forwards `isEmbedded` into the migrate runner |
+| [`legacy-ink-notice.ts`](../src/logic/utils/legacy-ink-notice.ts) | Notice UI; per-path tracking; `dismissLegacyInkNoticesForFile`; forwards `isEmbedded` |
+| Drawing/writing embed `openInDedicatedView` | Dismisses the migrate CTA before `saveAndHalt` + dedicated open |
 | [`migrate-legacy-ink-on-open.ts`](../src/logic/utils/migrate-legacy-ink-on-open.ts) | Single-file migrate (legacy extension or tldraw SVG); embed refresh; conditional dedicated reopen |
 | [`ink-embed-refresh.ts`](../src/components/formats/current/ink-embeds-extension/ink-embed-refresh.ts) | Rebuilds Live Preview writing/drawing widgets after the note stays active |
 
@@ -48,3 +57,5 @@ Call sites that show the notice (current ink-canvas editors and v1 tldraw editor
 - **Do not always reopen in a dedicated view after migrate.** `openInkFileInView` uses the active leaf. From an embed that leaf is the markdown note; opening an ink view replaces the note and also prevents `refreshLivePreviewEmbedsWhenReady` from seeing an active Live Preview markdown view.
 - **Dedicated reopen is still required for path changes.** Migrating `.writing` / `.drawing` produces a new `.svg` path; the dedicated leaf must open that file in the correct writing/drawing view type.
 - **Embed path depends on the note remaining active.** Refresh retries until the active view is source-mode Live Preview; stealing the leaf for an ink view makes refresh a no-op.
+- **One notice per file path.** Unlocking an embed and then opening the same attachment dedicated used to stack two migrate CTAs. Migrating from the first deleted `.writing`/`.drawing` while the second still pointed at the old path (ENOENT / “not eligible”). Notices are tracked per path, replaced on re-show, dismissed on expand-to-dedicated, and cleared after a successful migrate.
+- **Expand may rewrite tldraw SVG as ink-canvas.** `saveAndHalt` before dedicated open persists the in-memory ink-canvas snapshot. Dismissing the embed notice avoids a leftover migrate CTA against a file that is no longer tldraw on disk.

--- a/docs/legacy-migrate-on-open.md
+++ b/docs/legacy-migrate-on-open.md
@@ -1,0 +1,50 @@
+# Legacy migrate on open
+
+**Why it exists:** Opening a single legacy ink file shows a notice that can migrate just that attachment, without running the vault-wide migration modal. Users often hit legacy content while editing or reviewing embeds; a one-click path converts that file and keeps them in the same editing context when possible.
+
+## Conceptual understanding
+
+When a writing or drawing editor loads a legacy file (v1 `.writing` / `.drawing`, or an SVG that still stores tldraw metadata), Ink shows a persistent notice with **Migrate to new format**. That action permanently converts only the opened attachment, refreshes Live Preview embeds that reference it, and then either:
+
+- **stays on the markdown note** if migration started from an **embed**, or
+- **opens the converted SVG in a dedicated ink view** if migration started from a **dedicated** writing/drawing leaf.
+
+Bulk vault migration (Settings / command palette) remains a separate path; see [file-format-and-conversion.md](./file-format-and-conversion.md).
+
+## Flows
+
+```mermaid
+flowchart TD
+  Open["Open legacy writing or drawing editor"]
+  Notice["Show Legacy Ink file notice"]
+  Migrate["migrateLegacyInkFileOnOpen"]
+  Refresh["refreshLivePreviewEmbedsWhenReady"]
+  Embed{"isEmbedded?"}
+  Stay["Stay on markdown note"]
+  Dedicated["openInkFileInView for new SVG"]
+
+  Open --> Notice
+  Notice -->|"Migrate to new format"| Migrate
+  Migrate --> Refresh
+  Refresh --> Embed
+  Embed -->|yes| Stay
+  Embed -->|no| Dedicated
+```
+
+Editors pass `isEmbedded` from their existing `embedded` prop into `showLegacyInkUnlockNotice`. `runLegacyInkMigrationFromNotice` skips `openInkFileInView` when that flag is set.
+
+## Technical details
+
+| Piece | Role |
+|-------|------|
+| [`legacy-ink-notice.ts`](../src/logic/utils/legacy-ink-notice.ts) | Notice UI; forwards `isEmbedded` into the migrate runner |
+| [`migrate-legacy-ink-on-open.ts`](../src/logic/utils/migrate-legacy-ink-on-open.ts) | Single-file migrate (legacy extension or tldraw SVG); embed refresh; conditional dedicated reopen |
+| [`ink-embed-refresh.ts`](../src/components/formats/current/ink-embeds-extension/ink-embed-refresh.ts) | Rebuilds Live Preview writing/drawing widgets after the note stays active |
+
+Call sites that show the notice (current ink-canvas editors and v1 tldraw editors) all pass `isEmbedded: props.embedded`.
+
+## Technical Gotchas
+
+- **Do not always reopen in a dedicated view after migrate.** `openInkFileInView` uses the active leaf. From an embed that leaf is the markdown note; opening an ink view replaces the note and also prevents `refreshLivePreviewEmbedsWhenReady` from seeing an active Live Preview markdown view.
+- **Dedicated reopen is still required for path changes.** Migrating `.writing` / `.drawing` produces a new `.svg` path; the dedicated leaf must open that file in the correct writing/drawing view type.
+- **Embed path depends on the note remaining active.** Refresh retries until the active view is source-mode Live Preview; stealing the leaf for an ink view makes refresh a no-op.

--- a/src/components/formats/current/drawing/drawing-editor/drawing-editor.tsx
+++ b/src/components/formats/current/drawing/drawing-editor/drawing-editor.tsx
@@ -133,7 +133,7 @@ export function DrawingEditor(props: DrawingEditorProps) {
 
 	React.useEffect(() => {
 		if (!initialSnapshot || !isLegacyInkFileRef.current) return;
-		showLegacyInkUnlockNotice();
+		showLegacyInkUnlockNotice({ plugin: getGlobals().plugin, legacyFile: props.drawingFile });
 	}, [initialSnapshot]);
 
 	// Safety-net: clear timers on unmount

--- a/src/components/formats/current/drawing/drawing-editor/drawing-editor.tsx
+++ b/src/components/formats/current/drawing/drawing-editor/drawing-editor.tsx
@@ -133,7 +133,11 @@ export function DrawingEditor(props: DrawingEditorProps) {
 
 	React.useEffect(() => {
 		if (!initialSnapshot || !isLegacyInkFileRef.current) return;
-		showLegacyInkUnlockNotice({ plugin: getGlobals().plugin, legacyFile: props.drawingFile });
+		showLegacyInkUnlockNotice({
+			plugin: getGlobals().plugin,
+			legacyFile: props.drawingFile,
+			isEmbedded: props.embedded,
+		});
 	}, [initialSnapshot]);
 
 	// Safety-net: clear timers on unmount

--- a/src/components/formats/current/drawing/drawing-embed/drawing-embed.tsx
+++ b/src/components/formats/current/drawing/drawing-embed/drawing-embed.tsx
@@ -28,6 +28,7 @@ import { copyEmbedMarkdownToClipboard } from "src/logic/utils/copy-embed-to-clip
 import { EmbedPreviewContextMenu } from "src/components/jsx-components/embed-preview-context-menu/embed-preview-context-menu";
 import { replaceActiveInkEmbed, clearActiveInkEmbed } from "src/stores/active-ink-embed-store";
 import { extractInkJsonFromSvg } from "src/logic/utils/extractInkJsonFromSvg";
+import { dismissLegacyInkNoticesForFile } from "src/logic/utils/legacy-ink-notice";
 
 ///////
 ///////
@@ -494,6 +495,9 @@ export function DrawingEmbed (props: DrawingEmbed_Props) {
 
     async function openInDedicatedView() {
 		if (!props.embeddedFile) return;
+		// Drop the embed's migrate CTA before expand — saveAndHalt may already rewrite a
+		// tldraw SVG as ink-canvas, and a leftover notice would then fail as "not eligible".
+		dismissLegacyInkNoticesForFile(props.embeddedFile.path);
 		if (editorControlsRef.current) {
 			await editorControlsRef.current.saveAndHalt();
 		}

--- a/src/components/formats/current/writing/writing-editor/writing-editor.tsx
+++ b/src/components/formats/current/writing/writing-editor/writing-editor.tsx
@@ -149,7 +149,7 @@ export function WritingEditor(props: WritingEditorProps) {
 
 	React.useEffect(() => {
 		if (!initialSnapshot || !isLegacyInkFileRef.current) return;
-		showLegacyInkUnlockNotice();
+		showLegacyInkUnlockNotice({ plugin: props.plugin, legacyFile: props.writingFile });
 	}, [initialSnapshot]);
 
 	React.useEffect(() => {

--- a/src/components/formats/current/writing/writing-editor/writing-editor.tsx
+++ b/src/components/formats/current/writing/writing-editor/writing-editor.tsx
@@ -149,7 +149,11 @@ export function WritingEditor(props: WritingEditorProps) {
 
 	React.useEffect(() => {
 		if (!initialSnapshot || !isLegacyInkFileRef.current) return;
-		showLegacyInkUnlockNotice({ plugin: props.plugin, legacyFile: props.writingFile });
+		showLegacyInkUnlockNotice({
+			plugin: props.plugin,
+			legacyFile: props.writingFile,
+			isEmbedded: props.embedded,
+		});
 	}, [initialSnapshot]);
 
 	React.useEffect(() => {

--- a/src/components/formats/current/writing/writing-embed/writing-embed.tsx
+++ b/src/components/formats/current/writing/writing-embed/writing-embed.tsx
@@ -26,6 +26,7 @@ import { getGlobals } from "src/stores/global-store";
 import { type MenuOption } from "src/components/jsx-components/overflow-menu/overflow-menu";
 import { copyEmbedMarkdownToClipboard } from "src/logic/utils/copy-embed-to-clipboard";
 import { EmbedPreviewContextMenu } from "src/components/jsx-components/embed-preview-context-menu/embed-preview-context-menu";
+import { dismissLegacyInkNoticesForFile } from "src/logic/utils/legacy-ink-notice";
 
 ///////
 ///////
@@ -347,6 +348,9 @@ export function WritingEmbed (props: {
 
 	async function openInDedicatedView() {
 		if (!props.writingFileRef) return;
+		// Drop the embed migrate CTA before expand so a leftover notice cannot target a
+		// file that saveAndHalt may already have rewritten as ink-canvas.
+		dismissLegacyInkNoticesForFile(props.writingFileRef.path);
 		if (editorControlsRef.current) {
 			await editorControlsRef.current.saveAndHalt();
 		}

--- a/src/components/formats/v1-code-blocks/drawing/tldraw-drawing-editor/tldraw-drawing-editor.tsx
+++ b/src/components/formats/v1-code-blocks/drawing/tldraw-drawing-editor/tldraw-drawing-editor.tsx
@@ -75,7 +75,11 @@ export function TldrawDrawingEditor_v1(props: TldrawDrawingEditorProps_v1) {
 
 	React.useEffect(() => {
 		if (!tlEditorSnapshot) return;
-		showLegacyInkUnlockNotice({ plugin: props.plugin, legacyFile: props.drawingFile });
+		showLegacyInkUnlockNotice({
+			plugin: props.plugin,
+			legacyFile: props.drawingFile,
+			isEmbedded: props.embedded,
+		});
 	}, [tlEditorSnapshot]);
 
 	if(!tlEditorSnapshot) return <></>

--- a/src/components/formats/v1-code-blocks/drawing/tldraw-drawing-editor/tldraw-drawing-editor.tsx
+++ b/src/components/formats/v1-code-blocks/drawing/tldraw-drawing-editor/tldraw-drawing-editor.tsx
@@ -75,7 +75,7 @@ export function TldrawDrawingEditor_v1(props: TldrawDrawingEditorProps_v1) {
 
 	React.useEffect(() => {
 		if (!tlEditorSnapshot) return;
-		showLegacyInkUnlockNotice();
+		showLegacyInkUnlockNotice({ plugin: props.plugin, legacyFile: props.drawingFile });
 	}, [tlEditorSnapshot]);
 
 	if(!tlEditorSnapshot) return <></>

--- a/src/components/formats/v1-code-blocks/writing/tldraw-writing-editor/tldraw-writing-editor.tsx
+++ b/src/components/formats/v1-code-blocks/writing/tldraw-writing-editor/tldraw-writing-editor.tsx
@@ -80,7 +80,11 @@ export function TldrawWritingEditor_v1(props: TldrawWritingEditorProps_v1) {
 
 	React.useEffect(() => {
 		if (!tlEditorSnapshot) return;
-		showLegacyInkUnlockNotice({ plugin: props.plugin, legacyFile: props.writingFile });
+		showLegacyInkUnlockNotice({
+			plugin: props.plugin,
+			legacyFile: props.writingFile,
+			isEmbedded: props.embedded,
+		});
 	}, [tlEditorSnapshot]);
 
 	if(!tlEditorSnapshot) return <></>

--- a/src/components/formats/v1-code-blocks/writing/tldraw-writing-editor/tldraw-writing-editor.tsx
+++ b/src/components/formats/v1-code-blocks/writing/tldraw-writing-editor/tldraw-writing-editor.tsx
@@ -80,7 +80,7 @@ export function TldrawWritingEditor_v1(props: TldrawWritingEditorProps_v1) {
 
 	React.useEffect(() => {
 		if (!tlEditorSnapshot) return;
-		showLegacyInkUnlockNotice();
+		showLegacyInkUnlockNotice({ plugin: props.plugin, legacyFile: props.writingFile });
 	}, [tlEditorSnapshot]);
 
 	if(!tlEditorSnapshot) return <></>

--- a/src/logic/utils/legacy-ink-notice.ts
+++ b/src/logic/utils/legacy-ink-notice.ts
@@ -14,6 +14,39 @@ export type LegacyInkNoticeContext = {
 	isEmbedded?: boolean;
 };
 
+type TrackedLegacyInkNotice = {
+	filePath: string;
+	notice: Notice;
+};
+
+/** One persistent notice per legacy file — embed + dedicated must not stack stale CTAs. */
+const activeLegacyInkNotices: TrackedLegacyInkNotice[] = [];
+
+/**
+ * Hides any open "Legacy Ink file" notices for this attachment path.
+ * Used when expanding to a dedicated view or after a successful migrate so a
+ * leftover embed notice cannot migrate a file that was already converted/deleted.
+ */
+export function dismissLegacyInkNoticesForFile(filePath: string): void {
+	for (let index = activeLegacyInkNotices.length - 1; index >= 0; index--) {
+		const entry = activeLegacyInkNotices[index];
+		if (entry.filePath !== filePath) continue;
+		entry.notice.hide();
+		activeLegacyInkNotices.splice(index, 1);
+	}
+}
+
+function trackLegacyInkNotice(filePath: string, notice: Notice): void {
+	// Replace any prior notice for the same file (e.g. embed notice when dedicated mounts).
+	dismissLegacyInkNoticesForFile(filePath);
+	activeLegacyInkNotices.push({ filePath, notice });
+}
+
+function untrackLegacyInkNotice(notice: Notice): void {
+	const index = activeLegacyInkNotices.findIndex((entry) => entry.notice === notice);
+	if (index >= 0) activeLegacyInkNotices.splice(index, 1);
+}
+
 /**
  * Persistent CTA shown when a legacy ink editor mounts. Migration keeps the note
  * in place for embeds; dedicated views reopen the converted SVG (see migrate-legacy-ink-on-open).
@@ -31,6 +64,7 @@ export function showLegacyInkUnlockNotice(context: LegacyInkNoticeContext): void
 	});
 
 	const notice = launchPersistentNotice(noticeBody);
+	trackLegacyInkNotice(context.legacyFile.path, notice);
 
 	primaryBtnEl?.addEventListener('click', () => {
 		if (!primaryBtnEl || primaryBtnEl.disabled) return;
@@ -42,7 +76,7 @@ export function showLegacyInkUnlockNotice(context: LegacyInkNoticeContext): void
 				await runLegacyInkMigrationFromNotice(context.plugin, context.legacyFile, {
 					isEmbedded: context.isEmbedded,
 				});
-				notice.hide();
+				dismissLegacyInkNoticesForFile(context.legacyFile.path);
 			} catch (err) {
 				new Notice('Migration failed: ' + String(err));
 			} finally {
@@ -54,5 +88,6 @@ export function showLegacyInkUnlockNotice(context: LegacyInkNoticeContext): void
 
 	tertiaryBtnEl?.addEventListener('click', () => {
 		notice.hide();
+		untrackLegacyInkNotice(notice);
 	});
 }

--- a/src/logic/utils/legacy-ink-notice.ts
+++ b/src/logic/utils/legacy-ink-notice.ts
@@ -10,8 +10,14 @@ import { runLegacyInkMigrationFromNotice } from 'src/logic/utils/migrate-legacy-
 export type LegacyInkNoticeContext = {
 	plugin: InkPlugin;
 	legacyFile: TFile;
+	/** When true, migration refreshes the note embed in place instead of opening a dedicated ink view. */
+	isEmbedded?: boolean;
 };
 
+/**
+ * Persistent CTA shown when a legacy ink editor mounts. Migration keeps the note
+ * in place for embeds; dedicated views reopen the converted SVG (see migrate-legacy-ink-on-open).
+ */
 export function showLegacyInkUnlockNotice(context: LegacyInkNoticeContext): void {
 	const { noticeBody, scrollAreaEl, footerEl } = createNoticeTemplate();
 	scrollAreaEl.createEl('h1').setText('Legacy Ink file');
@@ -33,7 +39,9 @@ export function showLegacyInkUnlockNotice(context: LegacyInkNoticeContext): void
 
 		void (async (): Promise<void> => {
 			try {
-				await runLegacyInkMigrationFromNotice(context.plugin, context.legacyFile);
+				await runLegacyInkMigrationFromNotice(context.plugin, context.legacyFile, {
+					isEmbedded: context.isEmbedded,
+				});
 				notice.hide();
 			} catch (err) {
 				new Notice('Migration failed: ' + String(err));

--- a/src/logic/utils/legacy-ink-notice.ts
+++ b/src/logic/utils/legacy-ink-notice.ts
@@ -1,21 +1,48 @@
+import { Notice, TFile } from 'obsidian';
+import InkPlugin from 'src/main';
 import {
 	createNoticeCtaBar,
 	createNoticeTemplate,
 	launchPersistentNotice,
 } from 'src/components/dom-components/notice-components';
+import { runLegacyInkMigrationFromNotice } from 'src/logic/utils/migrate-legacy-ink-on-open';
 
-export function showLegacyInkUnlockNotice(): void {
+export type LegacyInkNoticeContext = {
+	plugin: InkPlugin;
+	legacyFile: TFile;
+};
+
+export function showLegacyInkUnlockNotice(context: LegacyInkNoticeContext): void {
 	const { noticeBody, scrollAreaEl, footerEl } = createNoticeTemplate();
-	scrollAreaEl.createEl('h1').setText('Legacy embed');
+	scrollAreaEl.createEl('h1').setText('Legacy Ink file');
 	scrollAreaEl.createEl('p').setText(
-		'This is a legacy embed and won\'t support all the newest features. Conversion is currently not possible but will be in a future release.',
+		'This is a legacy Ink file and won\'t support all the newest features. You can migrate it to the new SVG format now.',
 	);
 
-	const { tertiaryBtnEl } = createNoticeCtaBar(footerEl, {
+	const { primaryBtnEl, tertiaryBtnEl } = createNoticeCtaBar(footerEl, {
+		primaryLabel: 'Migrate to new format',
 		tertiaryLabel: 'Dismiss',
 	});
 
 	const notice = launchPersistentNotice(noticeBody);
+
+	primaryBtnEl?.addEventListener('click', () => {
+		if (!primaryBtnEl || primaryBtnEl.disabled) return;
+		primaryBtnEl.disabled = true;
+		primaryBtnEl.setText('Migrating…');
+
+		void (async (): Promise<void> => {
+			try {
+				await runLegacyInkMigrationFromNotice(context.plugin, context.legacyFile);
+				notice.hide();
+			} catch (err) {
+				new Notice('Migration failed: ' + String(err));
+			} finally {
+				primaryBtnEl.disabled = false;
+				primaryBtnEl.setText('Migrate to new format');
+			}
+		})();
+	});
 
 	tertiaryBtnEl?.addEventListener('click', () => {
 		notice.hide();

--- a/src/logic/utils/migrate-legacy-ink-on-open.ts
+++ b/src/logic/utils/migrate-legacy-ink-on-open.ts
@@ -1,0 +1,105 @@
+import { Notice, TFile } from 'obsidian';
+import InkPlugin from 'src/main';
+import { refreshLivePreviewEmbedsWhenReady } from 'src/components/formats/current/ink-embeds-extension/ink-embed-refresh';
+import { openInkFileInView } from 'src/logic/utils/open-file';
+import {
+	buildSingleLegacyFileScanResult,
+	executeMigration,
+	getLegacyInkFileType,
+	getLegacySvgPath,
+	isLegacyInkFilePath,
+} from 'src/logic/utils/migration-logic';
+import {
+	buildSingleTldrawSvgScanResult,
+	executeTldrawSvgMigration,
+} from 'src/logic/utils/tldraw-svg-migration-logic';
+
+export type LegacyInkMigrationOnOpenResult = {
+	openedFile: TFile;
+	viewType: 'inkWriting' | 'inkDrawing';
+};
+
+function resolveVaultLinkPath(
+	plugin: InkPlugin,
+	linkpath: string,
+	sourceNotePath: string,
+): string | null {
+	return plugin.app.metadataCache.getFirstLinkpathDest(linkpath, sourceNotePath)?.path ?? null;
+}
+
+/**
+ * Permanently migrates one legacy ink attachment opened from the editor notice.
+ * Handles v1 `.writing` / `.drawing` files and v2 SVG files that still store tldraw metadata.
+ */
+export async function migrateLegacyInkFileOnOpen(
+	plugin: InkPlugin,
+	legacyFile: TFile,
+): Promise<LegacyInkMigrationOnOpenResult> {
+	const vault = plugin.app.vault;
+
+	if (isLegacyInkFilePath(legacyFile.path)) {
+		const scanResult = await buildSingleLegacyFileScanResult(vault, legacyFile);
+		if (!scanResult) {
+			throw new Error('Could not prepare migration for this legacy file.');
+		}
+
+		const migrationResult = await executeMigration(vault, scanResult, undefined, {
+			singleLegacyFilePath: legacyFile.path,
+		});
+
+		if (migrationResult.convertedFiles === 0) {
+			const detail = migrationResult.failed[0] ?? migrationResult.skipped[0] ?? 'unknown error';
+			throw new Error(detail);
+		}
+
+		const fileType = getLegacyInkFileType(legacyFile.path);
+		if (!fileType) {
+			throw new Error('Could not determine legacy file type.');
+		}
+
+		const newSvgPath = getLegacySvgPath(legacyFile.path);
+		const openedFile = vault.getFileByPath(newSvgPath);
+		if (!openedFile) {
+			throw new Error('Migration completed but the new SVG file was not found.');
+		}
+
+		refreshLivePreviewEmbedsWhenReady(plugin);
+
+		return {
+			openedFile,
+			viewType: fileType === 'drawing' ? 'inkDrawing' : 'inkWriting',
+		};
+	}
+
+	const tldrawScanResult = await buildSingleTldrawSvgScanResult(
+		vault,
+		legacyFile,
+		(linkpath, sourceNotePath) => resolveVaultLinkPath(plugin, linkpath, sourceNotePath),
+	);
+	if (!tldrawScanResult) {
+		throw new Error('This file is not eligible for on-open migration.');
+	}
+
+	const tldrawMigrationResult = await executeTldrawSvgMigration(vault, tldrawScanResult);
+	if (tldrawMigrationResult.convertedFiles === 0) {
+		const detail = tldrawMigrationResult.failed[0] ?? tldrawMigrationResult.skipped[0] ?? 'unknown error';
+		throw new Error(detail);
+	}
+
+	const entry = tldrawScanResult.tldrawSvgFiles[0];
+	refreshLivePreviewEmbedsWhenReady(plugin);
+
+	return {
+		openedFile: entry.svgFile,
+		viewType: entry.fileKind === 'drawing' ? 'inkDrawing' : 'inkWriting',
+	};
+}
+
+export async function runLegacyInkMigrationFromNotice(
+	plugin: InkPlugin,
+	legacyFile: TFile,
+): Promise<void> {
+	const migrationResult = await migrateLegacyInkFileOnOpen(plugin, legacyFile);
+	new Notice('Migrated to the new SVG format.');
+	await openInkFileInView(migrationResult.openedFile, migrationResult.viewType);
+}

--- a/src/logic/utils/migrate-legacy-ink-on-open.ts
+++ b/src/logic/utils/migrate-legacy-ink-on-open.ts
@@ -98,8 +98,13 @@ export async function migrateLegacyInkFileOnOpen(
 export async function runLegacyInkMigrationFromNotice(
 	plugin: InkPlugin,
 	legacyFile: TFile,
+	options?: { isEmbedded?: boolean },
 ): Promise<void> {
 	const migrationResult = await migrateLegacyInkFileOnOpen(plugin, legacyFile);
 	new Notice('Migrated to the new SVG format.');
+	// Embeds already get a Live Preview rebuild from migrateLegacyInkFileOnOpen; opening a
+	// dedicated ink leaf would steal the active markdown note. Only reopen when migration
+	// started from a dedicated writing/drawing view (e.g. .writing → new .svg path).
+	if (options?.isEmbedded) return;
 	await openInkFileInView(migrationResult.openedFile, migrationResult.viewType);
 }

--- a/src/logic/utils/migration-logic.ts
+++ b/src/logic/utils/migration-logic.ts
@@ -235,6 +235,8 @@ export function getTestRunSvgPath(legacyFilePath: string): string {
 export type MigrationOptions = {
 	/** Write converted SVGs to {@link INK_TEST_CONVERSIONS_FOLDER}; do not update notes or delete legacy files. */
 	testRun?: boolean;
+	/** When set, note updates only replace legacy blocks for this legacy attachment path. */
+	singleLegacyFilePath?: string;
 };
 
 export function resolveMigrationOutputSvgPath(
@@ -252,6 +254,43 @@ async function ensureVaultFolderExists(vault: Vault, folderPath: string): Promis
 	if (!vault.getAbstractFileByPath(folderPath)) {
 		await vault.createFolder(folderPath);
 	}
+}
+
+/**
+ * Builds a vault scan result for migrating one legacy `.writing` / `.drawing` file.
+ */
+export async function buildSingleLegacyFileScanResult(
+	vault: Vault,
+	legacyFile: TFile,
+): Promise<VaultScanResult | null> {
+	const fileType = getLegacyInkFileType(legacyFile.path);
+	if (!fileType) return null;
+
+	const referencingNotes: TFile[] = [];
+
+	for (const note of vault.getMarkdownFiles()) {
+		let content: string;
+		try {
+			content = await vault.read(note);
+		} catch {
+			continue;
+		}
+
+		const blocks = findLegacyEmbedBlocks(content);
+		if (blocks.some(block => block.filepath === legacyFile.path)) {
+			referencingNotes.push(note);
+		}
+	}
+
+	return {
+		legacyFiles: [{
+			legacyFile,
+			fileType,
+			newSvgPath: getLegacySvgPath(legacyFile.path),
+			referencingNotes,
+		}],
+		affectedNotes: referencingNotes,
+	};
 }
 
 /**
@@ -351,11 +390,14 @@ export async function executeMigration(
 	};
 
 	const notesToUpdate = isTestRun ? [] : scanResult.affectedNotes;
-	const total = scanResult.legacyFiles.length + notesToUpdate.length;
+	const legacyFilesToConvert = options?.singleLegacyFilePath
+		? scanResult.legacyFiles.filter(entry => entry.legacyFile.path === options.singleLegacyFilePath)
+		: scanResult.legacyFiles;
+	const total = legacyFilesToConvert.length + notesToUpdate.length;
 	let done = 0;
 
 	logToVault(
-		'Migration started. Files: ' + scanResult.legacyFiles.length
+		'Migration started. Files: ' + legacyFilesToConvert.length
 		+ ', Notes: ' + notesToUpdate.length
 		+ (isTestRun ? ' (test run)' : ''),
 	);
@@ -365,13 +407,13 @@ export async function executeMigration(
 	}
 
 	const testRunSvgPathByLegacyPath = isTestRun
-		? buildTestRunSvgPathMap(scanResult.legacyFiles.map(entry => entry.legacyFile.path))
+		? buildTestRunSvgPathMap(legacyFilesToConvert.map(entry => entry.legacyFile.path))
 		: undefined;
 
 	const drawingEmbedSettingsBySvgPath = new Map<string, EmbedSettings>();
 
 	// Step 1: Convert each legacy file to SVG
-	for (const entry of scanResult.legacyFiles) {
+	for (const entry of legacyFilesToConvert) {
 		try {
 			const legacyJson = await vault.read(entry.legacyFile);
 			const inkFileData = convertLegacyToInkCanvasFileData(legacyJson, entry.fileType);
@@ -435,6 +477,9 @@ export async function executeMigration(
 			const blocks = findLegacyEmbedBlocks(content);
 
 			for (const block of blocks) {
+				if (options?.singleLegacyFilePath && block.filepath !== options.singleLegacyFilePath) {
+					continue;
+				}
 				const newSvgPath = resolveMigrationOutputSvgPath(block.filepath, options);
 				const newEmbed =
 					block.embedType === 'writing'

--- a/src/logic/utils/tldraw-svg-migration-logic.ts
+++ b/src/logic/utils/tldraw-svg-migration-logic.ts
@@ -246,6 +246,57 @@ export async function scanVaultForTldrawInkSvgFiles(
 }
 
 /**
+ * Builds a scan result for in-place migration of one tldraw-metadata SVG file.
+ */
+export async function buildSingleTldrawSvgScanResult(
+	vault: Vault,
+	svgFile: TFile,
+	resolveLinkPath: ResolveVaultLinkPath,
+): Promise<TldrawSvgVaultScanResult | null> {
+	const isTldraw = await isTldrawInkSvgFile(vault, svgFile);
+	if (!isTldraw) return null;
+
+	const referencingNotes: TFile[] = [];
+	let fileKind: 'writing' | 'drawing' | null = null;
+
+	for (const note of vault.getMarkdownFiles()) {
+		let content: string;
+		try {
+			content = await vault.read(note);
+		} catch {
+			continue;
+		}
+
+		for (const ref of findV2InkEmbedRefs(content)) {
+			const canonicalPath = resolveEmbedPath(vault, resolveLinkPath, ref.filepath, note.path);
+			if (canonicalPath !== svgFile.path) continue;
+			referencingNotes.push(note);
+			fileKind = ref.embedKind;
+			break;
+		}
+	}
+
+	if (!fileKind) {
+		const svgString = await vault.read(svgFile);
+		const inkFileData = extractInkJsonFromSvg(svgString);
+		if (inkFileData?.meta.fileType === 'inkWriting') fileKind = 'writing';
+		else if (inkFileData?.meta.fileType === 'inkDrawing') fileKind = 'drawing';
+	}
+
+	if (!fileKind) return null;
+
+	return {
+		tldrawSvgFiles: [{
+			svgFile,
+			fileKind,
+			newSvgPath: svgFile.path,
+			referencingNotes,
+		}],
+		affectedNotes: referencingNotes,
+	};
+}
+
+/**
  * Converts tldraw SVG files in place and updates drawing embed viewBox params in notes.
  */
 export async function executeTldrawSvgMigration(

--- a/tests/components/formats/current/utils/MigrationLogic.test.ts
+++ b/tests/components/formats/current/utils/MigrationLogic.test.ts
@@ -14,6 +14,7 @@ import {
 	scanVaultForLegacyEmbeds,
 	vaultHasLegacyInkFiles,
 	getLegacyInkFileType,
+	buildSingleLegacyFileScanResult,
 	executeMigration,
 	VaultScanResult,
 	LegacyEmbedBlock,
@@ -797,5 +798,57 @@ describe('executeMigration', () => {
 		expect(pathMap.get('Ink/Writing/foo.writing')).toBe(`${INK_TEST_CONVERSIONS_FOLDER}/foo.svg`);
 		expect(pathMap.get('Ink/Drawing/foo.drawing')).toBe(`${INK_TEST_CONVERSIONS_FOLDER}/foo_1.svg`);
 		expect(pathMap.get('Archive/foo.writing')).toBe(`${INK_TEST_CONVERSIONS_FOLDER}/foo_2.svg`);
+	});
+
+	test('singleLegacyFilePath only updates matching legacy blocks in a note', async () => {
+		const legacyJson = fs.readFileSync(LEGACY_WRITING_FIXTURE, 'utf8');
+		const otherLegacyPath = 'Ink/Writing/other.writing';
+		const noteContents = {
+			'Notes/A.md': `# Title\n\n${legacyWriteBlock(LEGACY_WRITE_PATH)}\n${legacyWriteBlock(otherLegacyPath)}\n`,
+		};
+		const vault = makeLegacyVault(noteContents, legacyJson);
+
+		const scanResult: VaultScanResult = {
+			legacyFiles: [
+				{
+					legacyFile: makeLegacyFile(LEGACY_WRITE_PATH),
+					fileType: 'writing',
+					newSvgPath: NEW_SVG_PATH,
+					referencingNotes: [makeNote('Notes/A.md')],
+				},
+				{
+					legacyFile: makeLegacyFile(otherLegacyPath),
+					fileType: 'writing',
+					newSvgPath: 'Ink/Writing/other.svg',
+					referencingNotes: [makeNote('Notes/A.md')],
+				},
+			],
+			affectedNotes: [makeNote('Notes/A.md')],
+		};
+
+		await executeMigration(vault as any, scanResult, undefined, {
+			singleLegacyFilePath: LEGACY_WRITE_PATH,
+		});
+
+		const modifiedContent = (vault.modify as jest.Mock).mock.calls[0][1] as string;
+		expect(modifiedContent).toContain('Ink/Writing/note.svg');
+		expect(modifiedContent).toContain(otherLegacyPath);
+		expect(modifiedContent).not.toContain(LEGACY_WRITE_PATH);
+	});
+});
+
+describe('buildSingleLegacyFileScanResult', () => {
+	test('returns scan result for one legacy file and its referencing notes', async () => {
+		const legacyPath = 'Ink/Writing/note.writing';
+		const vault = {
+			getMarkdownFiles: () => [{ path: 'Notes/A.md' } as TFile],
+			read: jest.fn(async () => `# Note\n\n\`\`\`handwritten-ink\n${JSON.stringify({ filepath: legacyPath })}\n\`\`\`\n`),
+		};
+
+		const result = await buildSingleLegacyFileScanResult(vault as any, { path: legacyPath } as TFile);
+
+		expect(result?.legacyFiles).toHaveLength(1);
+		expect(result?.legacyFiles[0].legacyFile.path).toBe(legacyPath);
+		expect(result?.affectedNotes).toHaveLength(1);
 	});
 });

--- a/tests/logic/utils/migrate-legacy-ink-on-open.test.ts
+++ b/tests/logic/utils/migrate-legacy-ink-on-open.test.ts
@@ -1,0 +1,98 @@
+import { TFile } from 'obsidian';
+import { migrateLegacyInkFileOnOpen } from 'src/logic/utils/migrate-legacy-ink-on-open';
+import {
+	buildSingleLegacyFileScanResult,
+	executeMigration,
+	getLegacySvgPath,
+} from 'src/logic/utils/migration-logic';
+import {
+	buildSingleTldrawSvgScanResult,
+	executeTldrawSvgMigration,
+} from 'src/logic/utils/tldraw-svg-migration-logic';
+
+jest.mock('src/logic/utils/migration-logic', () => ({
+	...jest.requireActual('src/logic/utils/migration-logic'),
+	buildSingleLegacyFileScanResult: jest.fn(),
+	executeMigration: jest.fn(),
+}));
+
+jest.mock('src/logic/utils/tldraw-svg-migration-logic', () => ({
+	...jest.requireActual('src/logic/utils/tldraw-svg-migration-logic'),
+	buildSingleTldrawSvgScanResult: jest.fn(),
+	executeTldrawSvgMigration: jest.fn(),
+}));
+
+jest.mock('src/components/formats/current/ink-embeds-extension/ink-embed-refresh', () => ({
+	refreshLivePreviewEmbedsWhenReady: jest.fn(),
+}));
+
+function makePlugin(vault: Record<string, unknown>) {
+	return {
+		app: {
+			vault,
+			metadataCache: {
+				getFirstLinkpathDest: jest.fn(),
+			},
+		},
+	} as any;
+}
+
+describe('migrateLegacyInkFileOnOpen', () => {
+	const legacyWritingFile = { path: 'Ink/Writing/note.writing', extension: 'writing' } as TFile;
+	const legacySvgFile = { path: 'Ink/Writing/note.svg', extension: 'svg' } as TFile;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('migrates a legacy .writing file to its .svg path', async () => {
+		const openedFile = { path: getLegacySvgPath(legacyWritingFile.path) } as TFile;
+		const vault = {
+			getFileByPath: jest.fn(() => openedFile),
+		};
+		const plugin = makePlugin(vault);
+
+		(buildSingleLegacyFileScanResult as jest.Mock).mockResolvedValueOnce({
+			legacyFiles: [],
+			affectedNotes: [],
+		});
+		(executeMigration as jest.Mock).mockResolvedValueOnce({ convertedFiles: 1, failed: [], skipped: [] });
+
+		const result = await migrateLegacyInkFileOnOpen(plugin, legacyWritingFile);
+
+		expect(executeMigration).toHaveBeenCalledWith(
+			vault,
+			expect.any(Object),
+			undefined,
+			{ singleLegacyFilePath: legacyWritingFile.path },
+		);
+		expect(result.openedFile).toBe(openedFile);
+		expect(result.viewType).toBe('inkWriting');
+	});
+
+	test('migrates a tldraw SVG file in place', async () => {
+		const plugin = makePlugin({});
+		const scanResult = {
+			tldrawSvgFiles: [{
+				svgFile: legacySvgFile,
+				fileKind: 'writing' as const,
+				newSvgPath: legacySvgFile.path,
+				referencingNotes: [],
+			}],
+			affectedNotes: [],
+		};
+
+		(buildSingleTldrawSvgScanResult as jest.Mock).mockResolvedValueOnce(scanResult);
+		(executeTldrawSvgMigration as jest.Mock).mockResolvedValueOnce({
+			convertedFiles: 1,
+			failed: [],
+			skipped: [],
+		});
+
+		const result = await migrateLegacyInkFileOnOpen(plugin, legacySvgFile);
+
+		expect(executeTldrawSvgMigration).toHaveBeenCalledWith(plugin.app.vault, scanResult);
+		expect(result.openedFile).toBe(legacySvgFile);
+		expect(result.viewType).toBe('inkWriting');
+	});
+});


### PR DESCRIPTION
## Summary

- Replaced the legacy-file dismiss-only notice with a **Migrate to new format** action that permanently converts the opened file only.
- Supported v1 `.writing` / `.drawing` attachments and v2 SVG files that still store tldraw metadata.
- Refreshed Live Preview embeds and reopened the converted SVG in the matching ink view after success.

## ClickUp

- [Option to convert legacy embeds on opening](https://app.clickup.com/t/86d3b9mhr) - `86d3b9mhr`

## Test plan

- [x] `npm run test:unit -- --testPathPattern="MigrationLogic|migrate-legacy-ink-on-open"`
- [x] `npm run build`

## Stack

Base: `release_0.5`
Depends on: none

Made with [Cursor](https://cursor.com)