### PR TITLE
fix: Live migration/progress modal stats

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -117,6 +117,8 @@ This builds the plugin, regenerates the vault from scratch (clearing all plugin 
 
 Use this when you want to manually inspect the plugin's behaviour against specific test scenarios, try out new features, or debug issues interactively.
 
+**Legacy migration progress UI:** Section **19 – Migration Progress Density** (see [qa-test-vault/README.md](../qa-test-vault/README.md)) seeds many unique `.writing` / `.drawing` files so **Migrate legacy ink embeds** scan/migrate progress bars and counters update visibly mid-run. Details: [file-format-and-conversion.md](./file-format-and-conversion.md#vault-migration-v1-code-blocks).
+
 For debugging with verbose logs (e.g. embed state transitions, activity tracking), use `npm run open-qa-verbose` instead. It builds in development mode so `verbose`, `debug`, and `http` logs appear in the DevTools console.
 
 For mobile UI emulation on desktop, use:

--- a/docs/file-format-and-conversion.md
+++ b/docs/file-format-and-conversion.md
@@ -88,10 +88,25 @@ flowchart TD
 
 **Test migration** (modal “test run”) is separate: it writes under `_ink-test-conversions/`, may append `_1` / `_2` basename suffixes on collisions within the batch, never deletes legacy files, and does not rewrite notes.
 
+**Progress UI:** Scan and migrate callbacks pass live counts (`found` during scan; `converted` / `skipped` / `failed` during migrate). The modal must use those callback arguments — not `scanResult` / `migrationResult`, which stay null until each `await` finishes.
+
+```mermaid
+flowchart LR
+  Scan["scanVaultForLegacyEmbeds"]
+  Migrate["executeMigration"]
+  Modal["MigrationModal"]
+  Scan -->|"onProgress scanned,total,foundCount"| Modal
+  Migrate -->|"onProgress done,total,liveStats"| Modal
+```
+
+**Manual QA (progress density):** With only a handful of legacy files, the bar and counters jump too fast to verify mid-run updates. After `node qa-test-vault/generate.mjs` (or `npm run open-qa`), open **19 - Migration Progress Density** — forty unique `.writing`/`.drawing` copies plus embeds, for watching scan/migrate stats tick. Prefer **Test Migration** so permanent delete does not wipe the set mid-session.
+
 ### Technical gotchas
 
 - Strokes that were in the legacy editor **stash** at last save are not in the v1 JSON and cannot be recovered (same limitation as before).
 - Permanent migration (bulk settings/command **and** on-open single-file) overwrites an existing same-path `.svg`. Legacy deletion runs only after create/overwrite succeeds; create, overwrite, or delete failures are reported in `failed` (and surface in the modal or on-open notice) without deleting the legacy file.
+- Mid-run modal stats must read callback args; assigning from `scanResult` / `migrationResult` inside `onProgress` always shows zeros until the phase completes.
+- A vault with few unique legacy attachments cannot expose progress-UI regressions — regenerate section 19 when validating the migration modal.
 - Open **Settings → Ink → Update Ink files…** or run the command **Migrate legacy ink embeds to ink-canvas**.
 - For migrating a **single** file from the editor notice (embed vs dedicated reopen rules), see [legacy-migrate-on-open.md](./legacy-migrate-on-open.md).
 

--- a/qa-test-vault/README.md
+++ b/qa-test-vault/README.md
@@ -40,3 +40,4 @@ All Ink files (SVGs and legacy .writing/.drawing) are copied from real captured 
 - **16 – V2 Tldraw Migration**: Real v2 `<tldraw>` SVGs; preview, edit, upgrade to ink-canvas on save
 - **17 – Tldraw Bulk Migration**: Developer modal — bulk tldraw → ink-canvas in place
 - **18 – Captured Legacy Migration**: Real v1 .writing/.drawing captures from production vaults
+- **19 – Migration Progress Density**: Many unique legacy files so scan/migrate progress bars visibly update

--- a/qa-test-vault/generate.mjs
+++ b/qa-test-vault/generate.mjs
@@ -495,6 +495,7 @@ All Ink files (SVGs and legacy .writing/.drawing) are copied from real captured 
 - **16 – V2 Tldraw Migration**: Real v2 \`<tldraw>\` SVGs; preview, edit, upgrade to ink-canvas on save
 - **17 – Tldraw Bulk Migration**: Developer modal — bulk tldraw → ink-canvas in place
 - **18 – Captured Legacy Migration**: Real v1 .writing/.drawing captures from production vaults
+- **19 – Migration Progress Density**: Many unique legacy files so scan/migrate progress bars visibly update
 `);
   generateConversionTestAssets();
   generateMigrationTestAssets();
@@ -503,6 +504,7 @@ All Ink files (SVGs and legacy .writing/.drawing) are copied from real captured 
   generateV2TldrawMigrationAssets();
   generateTldrawBulkMigrationAssets();
   generateCapturedLegacyMigrationAssets();
+  generateMigrationProgressDensityAssets();
 
   ensureDir('.obsidian');
   // Enable community plugins needed for column layout e2e tests.
@@ -971,6 +973,74 @@ ${writingList}
 ## Drawing captures
 
 ${drawingList}
+`);
+}
+
+// ─── Section 19: Migration Progress Density (many unique legacy files) ─────────
+// Enough distinct .writing/.drawing files that MigrationModal scan + convert
+// progress bars and live counters visibly tick instead of jumping 0 → done.
+
+const MIGRATION_PROGRESS_DENSITY_COUNT = 40;
+
+function generateMigrationProgressDensityAssets() {
+  ensureDir(path.join(VAULT_ROOT, 'Ink/Writing'));
+  ensureDir(path.join(VAULT_ROOT, 'Ink/Drawing'));
+  ensureDir(path.join(VAULT_ROOT, '19 - Migration Progress Density'));
+
+  const writingSrc = path.join(FIXTURES, 'legacy-writing-fixture.writing');
+  const drawingSrc = path.join(FIXTURES, 'legacy-drawing-fixture.drawing');
+
+  function buildLegacyWritingEmbed(filepath) {
+    return `\`\`\`handwritten-ink\n${JSON.stringify({ versionAtEmbed: PLUGIN_VERSION, filepath })}\n\`\`\``;
+  }
+  function buildLegacyDrawingEmbed(filepath) {
+    return `\`\`\`handdrawn-ink\n${JSON.stringify({ versionAtEmbed: PLUGIN_VERSION, filepath, width: 500, aspectRatio: 1 })}\n\`\`\``;
+  }
+
+  const noteLinks = [];
+  const half = Math.floor(MIGRATION_PROGRESS_DENSITY_COUNT / 2);
+
+  for (let i = 1; i <= MIGRATION_PROGRESS_DENSITY_COUNT; i++) {
+    const padded = String(i).padStart(2, '0');
+    const isWriting = i <= half;
+    const fileType = isWriting ? 'writing' : 'drawing';
+    const vaultSubfolder = isWriting ? 'Ink/Writing' : 'Ink/Drawing';
+    const basename = `progress-density-${padded}`;
+    const vaultPath = `${vaultSubfolder}/${basename}.${fileType}`;
+    const src = isWriting ? writingSrc : drawingSrc;
+    fs.copyFileSync(src, path.join(VAULT_ROOT, vaultPath));
+
+    const notePath = `19 - Migration Progress Density/${isWriting ? 'Writing' : 'Drawing'} ${padded}.md`;
+    const embed = isWriting
+      ? buildLegacyWritingEmbed(vaultPath)
+      : buildLegacyDrawingEmbed(vaultPath);
+
+    writeFile(notePath, `# Migration Progress Density — ${basename}
+
+Legacy \`.${fileType}\` copy for watching MigrationModal progress (found/converted/remaining).
+
+${embed}
+`);
+    noteLinks.push(`- \`${notePath}\` → \`${vaultPath}\``);
+  }
+
+  writeFile('19 - Migration Progress Density/README.md', `# Migration Progress Density
+
+Creates **${MIGRATION_PROGRESS_DENSITY_COUNT}** unique legacy \`.writing\` / \`.drawing\` files (plus notes with embeds) so **Migrate legacy ink embeds** shows live progress-bar and counter updates during scan and migrate.
+
+## Manual checklist
+
+1. Run \`node qa-test-vault/generate.mjs\` to reset the vault (recreates these files).
+2. Command palette → **Migrate legacy ink embeds to ink-canvas**.
+3. Watch scan: remaining/found should update while notes are scanned.
+4. Choose **Test Migration** (safer) or **Migrate Permanently**.
+5. Watch migrate: converted/remaining/skipped/failed should update mid-run (not stay at 0 until done).
+
+Together with sections 13 and 18, the vault should list well over ${MIGRATION_PROGRESS_DENSITY_COUNT} legacy files.
+
+## Files
+
+${noteLinks.join('\n')}
 `);
 }
 

--- a/src/components/dom-components/modals/file-conversion-modal/file-conversion-modal.ts
+++ b/src/components/dom-components/modals/file-conversion-modal/file-conversion-modal.ts
@@ -129,12 +129,13 @@ export class FileConversionModal extends Modal {
 				this.plugin.app.vault,
 				this.file.path,
 				fromType,
-				(scanned, total) => {
+				(scanned, total, foundCount) => {
 					const remaining = total - scanned;
 					const pct = total > 0 ? (scanned / total) * 100 : 100;
 					if (this.progressBarInnerEl) this.progressBarInnerEl.style.width = pct.toFixed(1) + '%';
 					if (this.remainingCountEl) this.remainingCountEl.setText(String(remaining));
-					if (this.convertedCountEl) this.convertedCountEl.setText(String(this.affectedNotes.length));
+					// foundCount comes from the scanner — affectedNotes is empty until await finishes
+					if (this.convertedCountEl) this.convertedCountEl.setText(String(foundCount));
 				},
 			);
 
@@ -362,17 +363,18 @@ export class FileConversionModal extends Modal {
 				this.affectedNotes,
 				moveToPath,
 				this.conversionScope,
-				(done, total) => {
+				(done, total, liveStats) => {
 					const pct = total > 0 ? (done / total) * 100 : 100;
 					if (this.progressBarInnerEl) this.progressBarInnerEl.style.width = pct.toFixed(1) + '%';
 					if (this.remainingCountEl) {
 						this.remainingCountEl.setText(String(total - done));
 					}
-					if (this.convertedCountEl && this.conversionResult) {
-						this.convertedCountEl.setText(String(this.conversionResult.updatedNotePaths.length));
+					// liveStats are required because conversionResult is only assigned after await
+					if (this.convertedCountEl) {
+						this.convertedCountEl.setText(String(liveStats.updatedNotes));
 					}
-					if (this.failedCountEl && this.conversionResult) {
-						this.failedCountEl.setText(String(this.conversionResult.failed.length));
+					if (this.failedCountEl) {
+						this.failedCountEl.setText(String(liveStats.failedCount));
 					}
 				},
 			);

--- a/src/components/dom-components/modals/migration-modal/migration-modal.ts
+++ b/src/components/dom-components/modals/migration-modal/migration-modal.ts
@@ -81,7 +81,7 @@ export class MigrationModal extends Modal {
 						this.progressBarInnerEl.style.width = pct.toFixed(1) + '%';
 					}
 					if (this.remainingCountEl) this.remainingCountEl.setText(String(remaining));
-					// foundCount comes from the scanner — scanResult is null until await finishes
+					// Live foundCount from the scanner — this.scanResult stays null until await ends.
 					if (this.convertedCountEl) this.convertedCountEl.setText(String(foundCount));
 				},
 			);
@@ -229,7 +229,7 @@ export class MigrationModal extends Modal {
 					const pct = tot > 0 ? (d / tot) * 100 : 100;
 					if (this.progressBarInnerEl) this.progressBarInnerEl.style.width = pct.toFixed(1) + '%';
 					if (this.remainingCountEl) this.remainingCountEl.setText(String(tot - d));
-					// liveStats are required because migrationResult is only assigned after await
+					// Mid-run counters must come from liveStats — migrationResult is null until await ends.
 					if (this.convertedCountEl) this.convertedCountEl.setText(String(liveStats.convertedFiles));
 					if (this.skippedCountEl) this.skippedCountEl.setText(String(liveStats.skippedCount));
 					if (this.failedCountEl) this.failedCountEl.setText(String(liveStats.failedCount));

--- a/src/components/dom-components/modals/migration-modal/migration-modal.ts
+++ b/src/components/dom-components/modals/migration-modal/migration-modal.ts
@@ -74,14 +74,15 @@ export class MigrationModal extends Modal {
 		try {
 			this.scanResult = await scanVaultForLegacyEmbeds(
 				this.plugin.app.vault,
-				(scanned, tot) => {
+				(scanned, tot, foundCount) => {
 					const remaining = tot - scanned;
 					const pct = tot > 0 ? (scanned / tot) * 100 : 100;
 					if (this.progressBarInnerEl) {
 						this.progressBarInnerEl.style.width = pct.toFixed(1) + '%';
 					}
 					if (this.remainingCountEl) this.remainingCountEl.setText(String(remaining));
-					if (this.convertedCountEl) this.convertedCountEl.setText(String(this.scanResult?.legacyFiles.length ?? 0));
+					// foundCount comes from the scanner — scanResult is null until await finishes
+					if (this.convertedCountEl) this.convertedCountEl.setText(String(foundCount));
 				},
 			);
 		} catch (err) {
@@ -224,16 +225,14 @@ export class MigrationModal extends Modal {
 			this.migrationResult = await executeMigration(
 				this.plugin.app.vault,
 				scan,
-				(d, tot) => {
+				(d, tot, liveStats) => {
 					const pct = tot > 0 ? (d / tot) * 100 : 100;
 					if (this.progressBarInnerEl) this.progressBarInnerEl.style.width = pct.toFixed(1) + '%';
 					if (this.remainingCountEl) this.remainingCountEl.setText(String(tot - d));
-
-					if (this.migrationResult) {
-						if (this.convertedCountEl) this.convertedCountEl.setText(String(this.migrationResult.convertedFiles));
-						if (this.skippedCountEl) this.skippedCountEl.setText(String(this.migrationResult.skipped.length));
-						if (this.failedCountEl) this.failedCountEl.setText(String(this.migrationResult.failed.length));
-					}
+					// liveStats are required because migrationResult is only assigned after await
+					if (this.convertedCountEl) this.convertedCountEl.setText(String(liveStats.convertedFiles));
+					if (this.skippedCountEl) this.skippedCountEl.setText(String(liveStats.skippedCount));
+					if (this.failedCountEl) this.failedCountEl.setText(String(liveStats.failedCount));
 				},
 				this.migrationOptions,
 			);

--- a/src/components/dom-components/modals/remove-embed-modal/remove-embed-modal.ts
+++ b/src/components/dom-components/modals/remove-embed-modal/remove-embed-modal.ts
@@ -88,12 +88,13 @@ export class RemoveEmbedModal extends Modal {
 				vault,
 				this.embeddedFile.path,
 				this.embedType,
-				(scanned, total) => {
+				(scanned, total, foundCount) => {
 					const remaining = total - scanned;
 					const pct = total > 0 ? (scanned / total) * 100 : 50;
 					if (this.progressBarInnerEl) this.progressBarInnerEl.style.width = pct.toFixed(1) + '%';
 					if (this.remainingCountEl) this.remainingCountEl.setText(String(remaining));
-					if (this.foundCountEl) this.foundCountEl.setText(String(this.affectedNotes.length));
+					// foundCount comes from the scanner — affectedNotes is empty until await finishes
+					if (this.foundCountEl) this.foundCountEl.setText(String(foundCount));
 				},
 			);
 			this.totalEmbedCount = await countFileEmbedOccurrencesInVault(

--- a/src/components/dom-components/modals/tldraw-svg-migration-modal/tldraw-svg-migration-modal.ts
+++ b/src/components/dom-components/modals/tldraw-svg-migration-modal/tldraw-svg-migration-modal.ts
@@ -74,15 +74,16 @@ export class TldrawSvgMigrationModal extends Modal {
 			this.scanResult = await scanVaultForTldrawInkSvgFiles(
 				this.plugin.app.vault,
 				resolveLinkPath,
-				(scanned, tot) => {
+				(scanned, tot, foundCount) => {
 					const remaining = tot - scanned;
 					const pct = tot > 0 ? (scanned / tot) * 100 : 100;
 					if (this.progressBarInnerEl) {
 						this.progressBarInnerEl.style.width = pct.toFixed(1) + '%';
 					}
 					if (this.remainingCountEl) this.remainingCountEl.setText(String(remaining));
+					// foundCount comes from the scanner — scanResult is null until await finishes
 					if (this.convertedCountEl) {
-						this.convertedCountEl.setText(String(this.scanResult?.tldrawSvgFiles.length ?? 0));
+						this.convertedCountEl.setText(String(foundCount));
 					}
 				},
 			);
@@ -182,21 +183,19 @@ export class TldrawSvgMigrationModal extends Modal {
 			this.migrationResult = await executeTldrawSvgMigration(
 				this.plugin.app.vault,
 				scan,
-				(d, tot) => {
+				(d, tot, liveStats) => {
 					const pct = tot > 0 ? (d / tot) * 100 : 100;
 					if (this.progressBarInnerEl) this.progressBarInnerEl.style.width = pct.toFixed(1) + '%';
 					if (this.remainingCountEl) this.remainingCountEl.setText(String(tot - d));
-
-					if (this.migrationResult) {
-						if (this.convertedCountEl) {
-							this.convertedCountEl.setText(String(this.migrationResult.convertedFiles));
-						}
-						if (this.skippedCountEl) {
-							this.skippedCountEl.setText(String(this.migrationResult.skipped.length));
-						}
-						if (this.failedCountEl) {
-							this.failedCountEl.setText(String(this.migrationResult.failed.length));
-						}
+					// liveStats are required because migrationResult is only assigned after await
+					if (this.convertedCountEl) {
+						this.convertedCountEl.setText(String(liveStats.convertedFiles));
+					}
+					if (this.skippedCountEl) {
+						this.skippedCountEl.setText(String(liveStats.skippedCount));
+					}
+					if (this.failedCountEl) {
+						this.failedCountEl.setText(String(liveStats.failedCount));
 					}
 				},
 			);

--- a/src/logic/utils/convert-file-embeds.ts
+++ b/src/logic/utils/convert-file-embeds.ts
@@ -113,13 +113,13 @@ export async function countFileEmbedOccurrencesInVault(
  * Scans the vault for markdown files that contain a v2 embed referencing the
  * given SVG file path with the given embed type.
  *
- * Calls onProgress(scanned, total) after each file is checked.
+ * Calls onProgress(scanned, total, foundCount) after each file is checked.
  */
 export async function findNotesContainingFileEmbed(
 	vault: Vault,
 	svgFilePath: string,
 	fromType: 'inkWriting' | 'inkDrawing',
-	onProgress?: (scanned: number, total: number) => void,
+	onProgress?: (scanned: number, total: number, foundCount: number) => void,
 ): Promise<TFile[]> {
 	const mdFiles = vault.getMarkdownFiles();
 	const total = mdFiles.length;
@@ -136,7 +136,7 @@ export async function findNotesContainingFileEmbed(
 		} catch (_) {
 			// Unreadable file – skip
 		}
-		onProgress?.(i + 1, total);
+		onProgress?.(i + 1, total, results.length);
 	}
 
 	return results;
@@ -262,6 +262,11 @@ async function duplicateFileForConversion(
 	return duplicateWritingFile(plugin, file, instigatingNote);
 }
 
+export type FileConversionRunProgress = {
+	updatedNotes: number;
+	failedCount: number;
+};
+
 /**
  * Performs the full file conversion:
  * 1. (Optional) duplicate the file (duplicate scope only).
@@ -269,7 +274,7 @@ async function duplicateFileForConversion(
  * 3. Converts the SVG content (write↔draw).
  * 4. Updates note embeds per scope.
  *
- * onProgress(done, total) is called after each step.
+ * onProgress(done, total, liveStats) is called after each step so the UI can update mid-run.
  */
 export async function executeFileConversion(
 	plugin: InkPlugin,
@@ -278,7 +283,7 @@ export async function executeFileConversion(
 	affectedNotes: TFile[],
 	moveToPath: string | null,
 	scope: FileConversionScope,
-	onProgress: (done: number, total: number) => void,
+	onProgress: (done: number, total: number, liveStats: FileConversionRunProgress) => void,
 ): Promise<FileConversionResult> {
 	const vault = plugin.app.vault;
 	const notesToUpdate = resolveNotesToUpdate(scope, affectedNotes);
@@ -296,6 +301,13 @@ export async function executeFileConversion(
 		finalFile: null,
 		originalFilePath: file.path,
 		wasDuplicated,
+	};
+
+	const reportProgress = () => {
+		onProgress(done, total, {
+			updatedNotes: result.updatedNotePaths.length,
+			failedCount: result.failed.length,
+		});
 	};
 
 	const oldPath = file.path;
@@ -319,7 +331,7 @@ export async function executeFileConversion(
 			return result;
 		}
 		done++;
-		onProgress(done, total);
+		reportProgress();
 	} else {
 		// Close any open ink views to prevent them from overwriting the converted file
 		closeLeavesWithFileOpen(plugin, oldPath);
@@ -334,7 +346,7 @@ export async function executeFileConversion(
 			result.failed.push(`Move failed: ${String(err)}`);
 		}
 		done++;
-		onProgress(done, total);
+		reportProgress();
 	}
 
 	const newPath = currentFile.path;
@@ -356,7 +368,7 @@ export async function executeFileConversion(
 		result.failed.push(`SVG conversion failed: ${String(err)}`);
 	}
 	done++;
-	onProgress(done, total);
+	reportProgress();
 
 	if (!svgConversionSucceeded) {
 		result.finalFile = currentFile;
@@ -372,7 +384,7 @@ export async function executeFileConversion(
 			result.failed.push(`${note.path}: ${String(err)}`);
 		}
 		done++;
-		onProgress(done, total);
+		reportProgress();
 	}
 
 	result.finalFile = currentFile;

--- a/src/logic/utils/migration-logic.ts
+++ b/src/logic/utils/migration-logic.ts
@@ -293,14 +293,21 @@ export async function buildSingleLegacyFileScanResult(
 	};
 }
 
+/** Live counters for migration execute progress UI (must be passed mid-run; result is only assigned after await). */
+export type MigrationRunProgress = {
+	convertedFiles: number;
+	skippedCount: number;
+	failedCount: number;
+};
+
 /**
  * Scans the vault for legacy `.writing` / `.drawing` files and notes with legacy embeds.
  * Returns a VaultScanResult with every legacy file to convert and notes to update.
- * Calls onProgress(scanned, total) after each markdown file is processed.
+ * Calls onProgress(scanned, total, foundCount) after each markdown file is processed.
  */
 export async function scanVaultForLegacyEmbeds(
 	vault: Vault,
-	onProgress?: (scanned: number, total: number) => void,
+	onProgress?: (scanned: number, total: number, foundCount: number) => void,
 ): Promise<VaultScanResult> {
 	const markdownFiles = vault.getMarkdownFiles();
 	const total = markdownFiles.length;
@@ -324,13 +331,13 @@ export async function scanVaultForLegacyEmbeds(
 		try {
 			content = await vault.read(note);
 		} catch (_) {
-			onProgress?.(i + 1, total);
+			onProgress?.(i + 1, total, legacyFileMap.size);
 			continue;
 		}
 
 		const blocks = findLegacyEmbedBlocks(content);
 		if (blocks.length === 0) {
-			onProgress?.(i + 1, total);
+			onProgress?.(i + 1, total, legacyFileMap.size);
 			continue;
 		}
 
@@ -348,7 +355,7 @@ export async function scanVaultForLegacyEmbeds(
 			}
 		}
 
-		onProgress?.(i + 1, total);
+		onProgress?.(i + 1, total, legacyFileMap.size);
 	}
 
 	return {
@@ -369,12 +376,12 @@ export type MigrationResult = {
 
 /**
  * Executes the migration: converts each legacy file to SVG and updates referencing notes.
- * Calls onProgress(done, total) after each step.
+ * Calls onProgress(done, total, liveStats) after each step so the UI can update mid-run.
  */
 export async function executeMigration(
 	vault: Vault,
 	scanResult: VaultScanResult,
-	onProgress?: (done: number, total: number) => void,
+	onProgress?: (done: number, total: number, liveStats: MigrationRunProgress) => void,
 	options?: MigrationOptions,
 ): Promise<MigrationResult> {
 	const isTestRun = options?.testRun === true;
@@ -412,6 +419,14 @@ export async function executeMigration(
 
 	const drawingEmbedSettingsBySvgPath = new Map<string, EmbedSettings>();
 
+	const reportProgress = () => {
+		onProgress?.(done, total, {
+			convertedFiles: result.convertedFiles,
+			skippedCount: result.skipped.length,
+			failedCount: result.failed.length,
+		});
+	};
+
 	// Step 1: Convert each legacy file to SVG
 	for (const entry of legacyFilesToConvert) {
 		try {
@@ -421,7 +436,7 @@ export async function executeMigration(
 			if (!inkFileData) {
 				result.skipped.push(entry.legacyFile.path + ' (could not parse)');
 				done++;
-				onProgress?.(done, total);
+				reportProgress();
 				continue;
 			}
 
@@ -477,7 +492,7 @@ export async function executeMigration(
 		}
 
 		done++;
-		onProgress?.(done, total);
+		reportProgress();
 	}
 
 	// Step 2: Update markdown notes
@@ -512,7 +527,7 @@ export async function executeMigration(
 		}
 
 		done++;
-		onProgress?.(done, total);
+		reportProgress();
 	}
 
 	logToVault('Migration complete. Converted: ' + result.convertedFiles + ', Failed: ' + result.failed.length + ', Skipped: ' + result.skipped.length);

--- a/src/logic/utils/migration-logic.ts
+++ b/src/logic/utils/migration-logic.ts
@@ -303,7 +303,8 @@ export type MigrationRunProgress = {
 /**
  * Scans the vault for legacy `.writing` / `.drawing` files and notes with legacy embeds.
  * Returns a VaultScanResult with every legacy file to convert and notes to update.
- * Calls onProgress(scanned, total, foundCount) after each markdown file is processed.
+ * Calls onProgress(scanned, total, foundCount) after each markdown file so the modal can
+ * show live found/remaining counts — callers must not read the eventual return value mid-scan.
  */
 export async function scanVaultForLegacyEmbeds(
 	vault: Vault,

--- a/src/logic/utils/tldraw-svg-migration-logic.ts
+++ b/src/logic/utils/tldraw-svg-migration-logic.ts
@@ -19,6 +19,7 @@ import {
 } from 'src/ink-canvas/migrate-from-tldraw';
 import { renderStrokesToSvg, renderWritingStrokesToSvg } from 'src/ink-canvas/svg-export';
 import type { EmbedSettings } from 'src/types/embed-settings';
+import type { MigrationRunProgress } from 'src/logic/utils/migration-logic';
 
 ////////
 ////////
@@ -180,7 +181,7 @@ function resolveEmbedPath(
 export async function scanVaultForTldrawInkSvgFiles(
 	vault: Vault,
 	resolveLinkPath: ResolveVaultLinkPath,
-	onProgress?: (scanned: number, total: number) => void,
+	onProgress?: (scanned: number, total: number, foundCount: number) => void,
 ): Promise<TldrawSvgVaultScanResult> {
 	const markdownFiles = vault.getMarkdownFiles();
 	const total = markdownFiles.length;
@@ -196,7 +197,7 @@ export async function scanVaultForTldrawInkSvgFiles(
 		try {
 			content = await vault.read(note);
 		} catch {
-			onProgress?.(i + 1, total);
+			onProgress?.(i + 1, total, fileMap.size);
 			continue;
 		}
 
@@ -236,7 +237,7 @@ export async function scanVaultForTldrawInkSvgFiles(
 			}
 		}
 
-		onProgress?.(i + 1, total);
+		onProgress?.(i + 1, total, fileMap.size);
 	}
 
 	return {
@@ -302,7 +303,7 @@ export async function buildSingleTldrawSvgScanResult(
 export async function executeTldrawSvgMigration(
 	vault: Vault,
 	scanResult: TldrawSvgVaultScanResult,
-	onProgress?: (done: number, total: number) => void,
+	onProgress?: (done: number, total: number, liveStats: MigrationRunProgress) => void,
 ): Promise<TldrawSvgMigrationResult> {
 	const result: TldrawSvgMigrationResult = {
 		convertedFiles: 0,
@@ -318,6 +319,14 @@ export async function executeTldrawSvgMigration(
 	const total = scanResult.tldrawSvgFiles.length + scanResult.affectedNotes.length;
 	let done = 0;
 
+	const reportProgress = () => {
+		onProgress?.(done, total, {
+			convertedFiles: result.convertedFiles,
+			skippedCount: result.skipped.length,
+			failedCount: result.failed.length,
+		});
+	};
+
 	logToVault(
 		'Tldraw SVG migration started. Files: '
 			+ scanResult.tldrawSvgFiles.length
@@ -332,7 +341,7 @@ export async function executeTldrawSvgMigration(
 			if (!inkFileData) {
 				result.skipped.push(entry.svgFile.path + ' (no ink JSON)');
 				done++;
-				onProgress?.(done, total);
+				reportProgress();
 				continue;
 			}
 
@@ -340,7 +349,7 @@ export async function executeTldrawSvgMigration(
 			if (!converted) {
 				result.skipped.push(entry.svgFile.path + ' (already ink-canvas or not tldraw)');
 				done++;
-				onProgress?.(done, total);
+				reportProgress();
 				continue;
 			}
 
@@ -364,7 +373,7 @@ export async function executeTldrawSvgMigration(
 		}
 
 		done++;
-		onProgress?.(done, total);
+		reportProgress();
 	}
 
 	for (const note of scanResult.affectedNotes) {
@@ -392,7 +401,7 @@ export async function executeTldrawSvgMigration(
 		}
 
 		done++;
-		onProgress?.(done, total);
+		reportProgress();
 	}
 
 	logToVault(


### PR DESCRIPTION
## Summary

- Progress callbacks now pass live found/converted/skipped/failed counts so scanning and migration modals update mid-run instead of staying at 0 until completion.
- Applied the same fix across legacy migration, tldraw SVG migration, file conversion, and remove-embed scan UIs.

## ClickUp

- [Progress windows for migration don't use most number things](https://app.clickup.com/t/86d3p7j5v) - `86d3p7j5v`

## Test plan

- [x] `npm run build` (tsc + esbuild)
- [ ] Open legacy migration modal and confirm found/converted/skipped/failed update during scan and migrate
- [ ] Spot-check tldraw SVG migration and file-conversion progress stats

## Stack

Base: `release_0.5`
Depends on: none

Made with [Cursor](https://cursor.com)