### PR TITLE
fix: Theme-correct SVGs in dedicated native views

### DIFF
--- a/docs/ink-colours-and-theming.md
+++ b/docs/ink-colours-and-theming.md
@@ -20,23 +20,30 @@ The SVG also carries small class names on strokes and lines so the app knows whi
 
 ### Display colours
 
-When Ink **shows** an embed inside Obsidian, it does not rely on the baked black and gray alone. It loads the SVG into the page as real SVG markup (not a flat image tag) and applies CSS that points at Obsidian’s theme variables.
+When Ink **shows** an ink SVG inside Obsidian, it does not rely on the baked black and gray alone. It loads the SVG into the page as real SVG markup (not a flat image tag) and applies CSS that points at Obsidian’s theme variables.
+
+That themed display path is shared across:
+
+- **Note embeds** (Live Preview and Reading mode locks)
+- **SVG file picker** thumbnails
+- **Obsidian’s native SVG leaf** when you open an ink `.svg` attachment directly (before switching into Ink’s custom writing/drawing editor)
 
 - **Pen strokes** use `--text-normal` — the same colour as body text in the current theme.
 - **Writing guide lines** use `--color-base-50` — a soft line colour that fits the theme.
 - **Optional writing background and drawing frame** use other theme surface colours when those settings are on.
 
-When you toggle light or dark mode, those variables change. The embed updates without resaving the SVG.
+When you toggle light or dark mode, those variables change. The preview updates without resaving the SVG.
 
 ```mermaid
 flowchart LR
     Save["Save to vault"]
     Baked["File: black strokes, gray lines"]
     Show["Show in Obsidian"]
+    Inline["Inline SVG in DOM"]
     Theme["CSS reads theme variables"]
     Screen["Screen matches current theme"]
     Save --> Baked
-    Show --> Theme --> Screen
+    Show --> Inline --> Theme --> Screen
     Baked -.->|"file unchanged"| Show
 ```
 
@@ -66,6 +73,31 @@ The file on disk stays black and gray. The preview overrides those for display o
 3. Guide lines pick up the writing-line colour; pen paths pick up text colour.
 4. You change theme → variables change → preview colours change immediately.
 
+### Opening an ink SVG in Obsidian’s native leaf
+
+Opening an attachment as a normal SVG file uses Obsidian’s built-in media view (`img` / `object`), which cannot recolour inner paths. Ink detects ink writing/drawing metadata, then:
+
+```mermaid
+flowchart TD
+    Open["Open ink SVG attachment"]
+    Native["Obsidian native SVG leaf"]
+    Suppress["Mark leaf awaiting-theme — hide img/object"]
+    Detect["ensureThemedNativeInkSvgView reads SVG"]
+    Mount["Mount inlined SVG under embed preview host class"]
+    Theme["ink-svg-preview-theme.scss applies --text-normal"]
+    Edit["Edit button switches to custom writing/drawing view"]
+    Open --> Native --> Suppress --> Detect
+    Detect --> Mount --> Theme
+    Detect --> Edit
+```
+
+1. `ensureThemedNativeInkSvgView` marks the leaf awaiting-theme **before** `vault.read`.
+2. It confirms ink metadata, then mounts themed chrome via `addEditButtonToSvgView`.
+3. Native media is hidden immediately (`ddc_ink_svg-view--awaiting-theme`, then `ddc_ink_svg-native-media--hidden` after mount).
+4. `mountInlineSvgPreview` parses the SVG string into a real `<svg>` under `ddc_ink_svg-native-view-preview` plus the same writing/drawing embed preview class used elsewhere.
+5. Shared rules in `ink-svg-preview-theme.scss` restyle paths to `var(--text-normal)`.
+6. If inline mount fails, native media is unhidden so the leaf still shows the baked file.
+
 ### Displaying outside Ink’s preview
 
 If something shows the SVG as a normal image (or you open the raw file in a browser), you see the **baked** black and gray. That is expected. Theme colours only apply when Ink’s preview CSS is active.
@@ -83,13 +115,24 @@ Constants for baked values live in `src/default-content-colours.ts`. Shared prev
 
 Ink must **inline** the SVG for theme CSS to reach individual paths and lines. A plain `<img src="file.svg">` tag treats the drawing as one bitmap-like object; inner paths cannot be restyled.
 
+| Surface | Entry | Mount helper | Theme host classes |
+|---------|-------|--------------|--------------------|
+| Note embeds | Embed preview components | `mountInlineSvgPreview` (or equivalent inline path) | `ddc_ink_writing-embed-preview` / `ddc_ink_drawing-embed-preview` |
+| SVG picker | `svg-picker-modal.ts` | `mountInlineSvgPreview` | Same embed preview classes |
+| Native SVG leaf | `ensureThemedNativeInkSvgView` (writing/drawing registers) | `mountInlineSvgPreview` | `ddc_ink_svg-native-view-preview` **plus** the matching embed preview class |
+
+Native-leaf layout (sizing, scroll, centered media) lives in `src/logic/utils/svg-edit-button.scss`. Colour overrides stay in the shared theme partial so dedicated native views cannot drift from embeds.
+
 ## Technical gotchas
 
-1. **Image embeds do not theme** — Reading mode must use Ink’s preview (inlined SVG), not Obsidian’s default image tag, or strokes stay black in dark mode.
+1. **Image tags do not theme** — Reading mode, the native SVG leaf, and any other `img`/`object` path must swap to (or hide behind) an inlined SVG preview, or strokes stay black in dark mode.
 2. **Baked black wins without CSS** — SVG `fill="#000000"` on a path is strong. Preview CSS uses `!important` so theme colour can override it inside Ink previews.
-3. **Editor vs file** — While editing, the canvas may still use live drawing colours. Only the **exported SVG** and **locked previews** follow the bake + theme rules described here.
-4. **Legacy files** — Older tldraw-era SVGs may use different stored colours. New ink-canvas exports follow black strokes and gray guide lines.
-5. **Print and share** — Exported files intentionally stay black/gray so hard copies stay legible.
+3. **Reuse embed host classes on the native leaf** — Native-view layout uses `ddc_ink_svg-native-view-preview`; colour comes from the same writing/drawing embed classes. Do not invent a parallel stroke-colour stylesheet for dedicated native views.
+4. **Hide native media before `vault.read`** — Ink marks the leaf with `ddc_ink_svg-view--awaiting-theme` synchronously on open so Obsidian’s `img`/`object` never paints baked-black strokes during the async read. Removing that early suppress brings back a dark-mode flash.
+5. **Hide native media only after a successful inline mount** — If parse/mount fails, restoring the `img`/`object` keeps the leaf usable with baked colours.
+6. **Editor vs file** — While editing, the canvas may still use live drawing colours. Only the **exported SVG** and **locked / native previews** follow the bake + theme rules described here.
+7. **Legacy files** — Older tldraw-era SVGs may use different stored colours. New ink-canvas exports follow black strokes and gray guide lines.
+8. **Print and share** — Exported files intentionally stay black/gray so hard copies stay legible.
 
 ## See also
 

--- a/src/components/formats/current/drawing/drawing-view/drawing-view.tsx
+++ b/src/components/formats/current/drawing/drawing-view/drawing-view.tsx
@@ -82,8 +82,8 @@ export function registerDrawingView (plugin: InkPlugin) {
             if (!inkFileData) return;
             if (inkFileData.meta.fileType !== "inkDrawing") return;
 
-            // Add edit button to the SVG view
-            addEditButtonToSvgView(plugin, leaf, file, DRAWING_VIEW_TYPE);
+            // Add edit button and theme-aware inline preview to the native SVG view
+            addEditButtonToSvgView(plugin, leaf, file, DRAWING_VIEW_TYPE, svgString, 'inkDrawing');
         } catch (_) {
             // Fail silently; fall back to default SVG handling
         }

--- a/src/components/formats/current/drawing/drawing-view/drawing-view.tsx
+++ b/src/components/formats/current/drawing/drawing-view/drawing-view.tsx
@@ -8,7 +8,7 @@ import {
 } from "jotai";
 import { buildFileStr } from "../../utils/buildFileStr";
 import { extractInkJsonFromSvg } from "src/logic/utils/extractInkJsonFromSvg";
-import { addEditButtonToSvgView } from "src/logic/utils/addEditButtonToSvgView";
+import { ensureThemedNativeInkSvgView } from "src/logic/utils/addEditButtonToSvgView";
 import { openInkFileInView, restoreSidebarsAfterInkView } from "src/logic/utils/open-file";
 import { FileConversionModal } from "src/components/dom-components/modals/file-conversion-modal/file-conversion-modal";
 import { ConfirmationModal } from "src/components/dom-components/modals/confirmation-modal/confirmation-modal";
@@ -61,52 +61,25 @@ export function registerDrawingView (plugin: InkPlugin) {
         (leaf) => new DrawingView(leaf, plugin)
     );
 
-    // Helper function to check and add edit button for drawing files
-    async function checkAndAddEditButton(leaf: WorkspaceLeaf, file: TFile) {
-        if (!file || file.extension !== 'svg') return;
-        
-        const currentViewType = leaf.view?.getViewType?.();
-        // Skip if already in our custom view
-        if (currentViewType === DRAWING_VIEW_TYPE) return;
-
-        try {
-            const svgString = await plugin.app.vault.read(file);
-            if (!svgString || !svgString.trim().startsWith('<svg')) return;
-
-            // Re-check after the async read — the leaf may have transitioned to
-            // DRAWING_VIEW_TYPE while vault.read was awaited (race condition when
-            // opening via Obsidian Menu whose onClick is not awaited by Obsidian)
-            if (leaf.view?.getViewType?.() === DRAWING_VIEW_TYPE) return;
-
-            const inkFileData = extractInkJsonFromSvg(svgString);
-            if (!inkFileData) return;
-            if (inkFileData.meta.fileType !== "inkDrawing") return;
-
-            // Add edit button and theme-aware inline preview to the native SVG view
-            addEditButtonToSvgView(plugin, leaf, file, DRAWING_VIEW_TYPE, svgString, 'inkDrawing');
-        } catch (_) {
-            // Fail silently; fall back to default SVG handling
-        }
-    }
-
-    // Add edit button to SVG views that contain ink drawing data
+    // Native SVG leaf theming is owned by ensureThemedNativeInkSvgView (also registered
+    // from writing-view). Keep a second hook so drawing SVGs still theme if event
+    // ordering only hits this register path; in-flight lock dedupes concurrent calls.
     plugin.registerEvent(
         plugin.app.workspace.on('file-open', async (file) => {
             if (!file) return;
             const targetLeaf = plugin.app.workspace.getMostRecentLeaf();
             if (targetLeaf) {
-                await checkAndAddEditButton(targetLeaf, file);
+                await ensureThemedNativeInkSvgView(plugin, targetLeaf, file);
             }
         })
     );
 
-    // Also check when a leaf becomes active (e.g., when navigating back)
     plugin.registerEvent(
         plugin.app.workspace.on('active-leaf-change', async (leaf) => {
             if (!leaf) return;
             const view = leaf.view;
             if (view instanceof FileView && view.file) {
-                await checkAndAddEditButton(leaf, view.file);
+                await ensureThemedNativeInkSvgView(plugin, leaf, view.file);
             }
         })
     );

--- a/src/components/formats/current/writing/writing-view/writing-view.tsx
+++ b/src/components/formats/current/writing/writing-view/writing-view.tsx
@@ -9,7 +9,7 @@ import { type MenuOption } from "src/components/jsx-components/overflow-menu/ove
 import { buildFileStr } from "../../utils/buildFileStr";
 import { extractInkJsonFromSvg } from "src/logic/utils/extractInkJsonFromSvg";
 import { WritingEditorControls } from "../writing-embed/writing-embed";
-import { addEditButtonToSvgView } from "src/logic/utils/addEditButtonToSvgView";
+import { ensureThemedNativeInkSvgView } from "src/logic/utils/addEditButtonToSvgView";
 import { openInkFileInView, restoreSidebarsAfterInkView } from "src/logic/utils/open-file";
 import { FileConversionModal } from "src/components/dom-components/modals/file-conversion-modal/file-conversion-modal";
 import { ConfirmationModal } from "src/components/dom-components/modals/confirmation-modal/confirmation-modal";
@@ -29,53 +29,24 @@ export function registerWritingView (plugin: InkPlugin) {
         (leaf) => new WritingView(leaf, plugin)
     );
 
-    // Helper function to check and add edit button for writing files
-    async function checkAndAddEditButton(leaf: WorkspaceLeaf, file: TFile) {
-        if (!file || file.extension !== 'svg') return;
-        if (!leaf) return;
-        
-        const currentViewType = leaf.view?.getViewType?.();
-        // Skip if already in our custom view
-        if (currentViewType === WRITING_VIEW_TYPE) return;
-
-        try {
-            const svgString = await plugin.app.vault.read(file);
-            if (!svgString || !svgString.trim().startsWith('<svg')) return;
-
-            // Re-check after the async read — the leaf may have transitioned to
-            // WRITING_VIEW_TYPE while vault.read was awaited (race condition when
-            // opening via Obsidian Menu whose onClick is not awaited by Obsidian)
-            if (leaf.view?.getViewType?.() === WRITING_VIEW_TYPE) return;
-
-            const inkFileData = extractInkJsonFromSvg(svgString);
-            if (!inkFileData) return;
-            if (inkFileData.meta.fileType !== "inkWriting") return;
-
-            // Add edit button and theme-aware inline preview to the native SVG view
-            addEditButtonToSvgView(plugin, leaf, file, WRITING_VIEW_TYPE, svgString, 'inkWriting');
-        } catch (_) {
-            // Fail silently; fall back to default SVG handling
-        }
-    }
-
-    // Add edit button to SVG views that contain ink writing data
+    // Native SVG leaf: suppress black-img flash early, then theme + Edit when ink.
+    // Shared with drawing via ensureThemedNativeInkSvgView (handles both file types).
     plugin.registerEvent(
         plugin.app.workspace.on('file-open', async (file) => {
             if (!file) return;
             const targetLeaf = plugin.app.workspace.getMostRecentLeaf();
             if (targetLeaf) {
-                await checkAndAddEditButton(targetLeaf, file);
+                await ensureThemedNativeInkSvgView(plugin, targetLeaf, file);
             }
         })
     );
 
-    // Also check when a leaf becomes active (e.g., when navigating back)
     plugin.registerEvent(
         plugin.app.workspace.on('active-leaf-change', async (leaf) => {
             if (!leaf) return;
             const view = leaf.view;
             if (view instanceof FileView && view.file) {
-                await checkAndAddEditButton(leaf, view.file);
+                await ensureThemedNativeInkSvgView(plugin, leaf, view.file);
             }
         })
     );

--- a/src/components/formats/current/writing/writing-view/writing-view.tsx
+++ b/src/components/formats/current/writing/writing-view/writing-view.tsx
@@ -51,8 +51,8 @@ export function registerWritingView (plugin: InkPlugin) {
             if (!inkFileData) return;
             if (inkFileData.meta.fileType !== "inkWriting") return;
 
-            // Add edit button to the SVG view
-            addEditButtonToSvgView(plugin, leaf, file, WRITING_VIEW_TYPE);
+            // Add edit button and theme-aware inline preview to the native SVG view
+            addEditButtonToSvgView(plugin, leaf, file, WRITING_VIEW_TYPE, svgString, 'inkWriting');
         } catch (_) {
             // Fail silently; fall back to default SVG handling
         }

--- a/src/components/shared/ink-svg-preview-theme.scss
+++ b/src/components/shared/ink-svg-preview-theme.scss
@@ -1,4 +1,5 @@
-// Shared stroke colours for inlined ink SVG previews (embeds + file picker modal).
+// Shared stroke colours for inlined ink SVG previews (embeds, file picker modal,
+// and native SVG leaf after ensureThemedNativeInkSvgView mounts a themed host).
 // SVG must be in the DOM (not img) for these rules to apply.
 
 .ddc_ink_writing-embed-preview,

--- a/src/logic/utils/addEditButtonToSvgView.ts
+++ b/src/logic/utils/addEditButtonToSvgView.ts
@@ -1,86 +1,135 @@
 import { FileView, TFile, WorkspaceLeaf } from "obsidian";
 import InkPlugin from "src/main";
+import {
+	embedPreviewClassForFileType,
+	mountInlineSvgPreview,
+} from "src/logic/utils/inline-svg-preview";
 import "./svg-edit-button.scss";
 
 ////////
 ////////
 
+const THEMED_PREVIEW_HOST_CLASS = 'ddc_ink_svg-native-view-preview';
+
+/**
+ * Overlay an Edit button on Obsidian's native SVG leaf, and replace the baked-black
+ * img/object display with an inlined SVG so theme stroke CSS can recolour paths.
+ */
 export function addEditButtonToSvgView(
-    plugin: InkPlugin,
-    leaf: WorkspaceLeaf,
-    file: TFile,
-    viewType: string
+	plugin: InkPlugin,
+	leaf: WorkspaceLeaf,
+	file: TFile,
+	viewType: string,
+	svgString: string,
+	fileType: 'inkWriting' | 'inkDrawing',
 ) {
-    // Wait for the SVG view to be rendered
-    window.setTimeout(() => {
-        const view = leaf.view;
-        if (!view) return;
+	// Wait for the SVG view to be rendered
+	window.setTimeout(() => {
+		const view = leaf.view;
+		if (!view) return;
 
-        // Find the view container
-        const containerEl = view.containerEl;
-        if (!containerEl) return;
+		// Find the view container
+		const containerEl = view.containerEl;
+		if (!containerEl) return;
 
-        // Check if button already exists
-        if (containerEl.querySelector('.ddc_ink_svg-edit-button')) return;
+		// Check if button already exists
+		if (containerEl.querySelector('.ddc_ink_svg-edit-button')) return;
 
-        // Find the view content area - Obsidian's SVG view typically uses .view-content
-        const viewContent = containerEl.querySelector('.view-content') || 
-                           containerEl.querySelector('.markdown-source-view') ||
-                           containerEl;
-        
-        // Ensure the container has relative positioning for absolute button positioning
-        const computedStyle = window.getComputedStyle(viewContent);
-        if (computedStyle.position === 'static') {
-            viewContent.classList.add('ddc_ink_svg-view-content--anchor');
-        }
-        
-        // Create the button container
-        const buttonContainer = document.createElement('div');
-        buttonContainer.className = 'ddc_ink_svg-edit-button-container';
-        
-        // Determine button text based on view type
-        const isDrawing = viewType.includes('drawing');
-        const buttonText = isDrawing ? 'Edit drawing' : 'Edit writing';
-        
-        // Create the edit button
-        const editButton = document.createElement('button');
-        editButton.className = 'ddc_ink_btn-slim ddc_ink_svg-edit-button';
-        editButton.textContent = buttonText;
-        editButton.title = `Edit ${isDrawing ? 'drawing' : 'writing'} in custom view`;
-        
-        // Handle button click
-        editButton.addEventListener('click', (e) => {
-            e.stopPropagation();
-            e.preventDefault();
-            
-            void leaf.setViewState({
-                type: viewType,
-                state: { file: file.path },
-                active: true,
-            });
-        });
-        
-        buttonContainer.appendChild(editButton);
-        viewContent.appendChild(buttonContainer);
-        
-        // Clean up when the view changes
-        const cleanup = () => {
-            const existingButton = containerEl.querySelector('.ddc_ink_svg-edit-button-container');
-            if (existingButton) {
-                existingButton.remove();
-            }
-        };
-        
-        // Register cleanup on file close
-        plugin.registerEvent(
-            plugin.app.workspace.on('file-open', () => {
-                // Clean up when a different file is opened
-                const currentView = leaf.view;
-                if (currentView instanceof FileView && currentView.file !== file) {
-                    cleanup();
-                }
-            })
-        );
-    }, 100);
+		// Find the view content area - Obsidian's SVG view typically uses .view-content
+		const viewContent = containerEl.querySelector('.view-content') ||
+			containerEl.querySelector('.markdown-source-view') ||
+			containerEl;
+
+		// Ensure the container has relative positioning for absolute button positioning
+		const computedStyle = window.getComputedStyle(viewContent);
+		if (computedStyle.position === 'static') {
+			viewContent.classList.add('ddc_ink_svg-view-content--anchor');
+		}
+
+		mountThemedNativeViewPreview(viewContent as HTMLElement, svgString, fileType);
+
+		// Create the button container
+		const buttonContainer = document.createElement('div');
+		buttonContainer.className = 'ddc_ink_svg-edit-button-container';
+
+		// Determine button text based on view type
+		const isDrawing = viewType.includes('drawing');
+		const buttonText = isDrawing ? 'Edit drawing' : 'Edit writing';
+
+		// Create the edit button
+		const editButton = document.createElement('button');
+		editButton.className = 'ddc_ink_btn-slim ddc_ink_svg-edit-button';
+		editButton.textContent = buttonText;
+		editButton.title = `Edit ${isDrawing ? 'drawing' : 'writing'} in custom view`;
+
+		// Handle button click
+		editButton.addEventListener('click', (e) => {
+			e.stopPropagation();
+			e.preventDefault();
+
+			void leaf.setViewState({
+				type: viewType,
+				state: { file: file.path },
+				active: true,
+			});
+		});
+
+		buttonContainer.appendChild(editButton);
+		viewContent.appendChild(buttonContainer);
+
+		// Clean up when the view changes
+		const cleanup = () => {
+			const existingButton = containerEl.querySelector('.ddc_ink_svg-edit-button-container');
+			if (existingButton) {
+				existingButton.remove();
+			}
+			const existingPreview = containerEl.querySelector(`.${THEMED_PREVIEW_HOST_CLASS}`);
+			if (existingPreview) {
+				existingPreview.remove();
+			}
+			containerEl.querySelectorAll('.ddc_ink_svg-native-media--hidden').forEach((el) => {
+				el.classList.remove('ddc_ink_svg-native-media--hidden');
+			});
+		};
+
+		// Register cleanup on file close
+		plugin.registerEvent(
+			plugin.app.workspace.on('file-open', () => {
+				// Clean up when a different file is opened
+				const currentView = leaf.view;
+				if (currentView instanceof FileView && currentView.file !== file) {
+					cleanup();
+				}
+			})
+		);
+	}, 100);
 }
 
+/**
+ * Hide Obsidian's native img/object media and mount an inlined SVG under the
+ * writing/drawing preview host class so ink-svg-preview-theme.scss applies.
+ */
+function mountThemedNativeViewPreview(
+	viewContent: HTMLElement,
+	svgString: string,
+	fileType: 'inkWriting' | 'inkDrawing',
+) {
+	if (viewContent.querySelector(`.${THEMED_PREVIEW_HOST_CLASS}`)) return;
+
+	const nativeMedia = viewContent.querySelectorAll('img, object, embed');
+	nativeMedia.forEach((el) => {
+		el.classList.add('ddc_ink_svg-native-media--hidden');
+	});
+
+	const previewHost = document.createElement('div');
+	previewHost.className = `${THEMED_PREVIEW_HOST_CLASS} ${embedPreviewClassForFileType(fileType)}`;
+	if (!mountInlineSvgPreview(previewHost, svgString)) {
+		// Restore native media if inline mount fails so the leaf still shows something
+		nativeMedia.forEach((el) => {
+			el.classList.remove('ddc_ink_svg-native-media--hidden');
+		});
+		return;
+	}
+
+	viewContent.appendChild(previewHost);
+}

--- a/src/logic/utils/addEditButtonToSvgView.ts
+++ b/src/logic/utils/addEditButtonToSvgView.ts
@@ -1,5 +1,6 @@
 import { FileView, TFile, WorkspaceLeaf } from "obsidian";
 import InkPlugin from "src/main";
+import { extractInkJsonFromSvg } from "src/logic/utils/extractInkJsonFromSvg";
 import {
 	embedPreviewClassForFileType,
 	mountInlineSvgPreview,
@@ -10,111 +11,265 @@ import "./svg-edit-button.scss";
 ////////
 
 const THEMED_PREVIEW_HOST_CLASS = 'ddc_ink_svg-native-view-preview';
+/** Marks the leaf while vault.read / mount run so baked-black img never paints. */
+const AWAITING_THEME_CLASS = 'ddc_ink_svg-view--awaiting-theme';
+const MAX_MOUNT_ATTEMPTS = 30;
+
+// Keep in sync with WRITING_VIEW_TYPE / DRAWING_VIEW_TYPE exports (avoid circular imports).
+const INK_WRITING_VIEW_TYPE = 'ink_writing-view';
+const INK_DRAWING_VIEW_TYPE = 'ink_drawing-view';
+
+/** Prevents file-open + active-leaf-change (and dual registers) from racing the same leaf. */
+const themingInFlightByLeafFileKey = new Set<string>();
+
+/**
+ * Hide native SVG media immediately so Obsidian cannot paint baked-black strokes
+ * before the themed inline preview mounts.
+ */
+function suppressNativeSvgFlash(leaf: WorkspaceLeaf) {
+	leaf.view?.containerEl?.classList.add(AWAITING_THEME_CLASS);
+}
+
+/**
+ * Undo flash suppression when the SVG is not ink (or mount is abandoned).
+ */
+function releaseNativeSvgFlashSuppression(leaf: WorkspaceLeaf) {
+	leaf.view?.containerEl?.classList.remove(AWAITING_THEME_CLASS);
+}
+
+/**
+ * On opening an `.svg` in Obsidian's native leaf: suppress black-img flash early,
+ * then mount a theme-aware inline preview + Edit button when the file is ink.
+ * Safe to call from both writing and drawing registers / multiple workspace events.
+ */
+export async function ensureThemedNativeInkSvgView(
+	plugin: InkPlugin,
+	leaf: WorkspaceLeaf,
+	file: TFile,
+) {
+	if (!file || file.extension !== 'svg' || !leaf) return;
+
+	const currentViewType = leaf.view?.getViewType?.();
+	if (currentViewType === INK_WRITING_VIEW_TYPE || currentViewType === INK_DRAWING_VIEW_TYPE) {
+		return;
+	}
+
+	const leafId = leaf.id ?? '';
+	const inFlightKey = `${leafId}:${file.path}`;
+	if (themingInFlightByLeafFileKey.has(inFlightKey)) return;
+	themingInFlightByLeafFileKey.add(inFlightKey);
+
+	const finishEnsure = () => {
+		themingInFlightByLeafFileKey.delete(inFlightKey);
+	};
+
+	// Sync — before await — so media that appears during vault.read stays invisible.
+	suppressNativeSvgFlash(leaf);
+
+	try {
+		const svgString = await plugin.app.vault.read(file);
+		if (!svgString || !svgString.trim().startsWith('<svg')) {
+			releaseNativeSvgFlashSuppression(leaf);
+			finishEnsure();
+			return;
+		}
+
+		const viewTypeAfterRead = leaf.view?.getViewType?.();
+		// Leaf may have switched to the custom ink editor while we were reading.
+		if (
+			viewTypeAfterRead === INK_WRITING_VIEW_TYPE ||
+			viewTypeAfterRead === INK_DRAWING_VIEW_TYPE
+		) {
+			releaseNativeSvgFlashSuppression(leaf);
+			finishEnsure();
+			return;
+		}
+
+		const inkFileData = extractInkJsonFromSvg(svgString);
+		if (!inkFileData) {
+			releaseNativeSvgFlashSuppression(leaf);
+			finishEnsure();
+			return;
+		}
+
+		if (inkFileData.meta.fileType === 'inkWriting') {
+			addEditButtonToSvgView(
+				plugin,
+				leaf,
+				file,
+				INK_WRITING_VIEW_TYPE,
+				svgString,
+				'inkWriting',
+				finishEnsure,
+			);
+			return;
+		}
+
+		if (inkFileData.meta.fileType === 'inkDrawing') {
+			addEditButtonToSvgView(
+				plugin,
+				leaf,
+				file,
+				INK_DRAWING_VIEW_TYPE,
+				svgString,
+				'inkDrawing',
+				finishEnsure,
+			);
+			return;
+		}
+
+		releaseNativeSvgFlashSuppression(leaf);
+		finishEnsure();
+	} catch (_) {
+		releaseNativeSvgFlashSuppression(leaf);
+		finishEnsure();
+	}
+}
 
 /**
  * Overlay an Edit button on Obsidian's native SVG leaf, and replace the baked-black
  * img/object display with an inlined SVG so theme stroke CSS can recolour paths.
+ * Caller must already have suppressed the native-media flash for this open.
  */
-export function addEditButtonToSvgView(
+function addEditButtonToSvgView(
 	plugin: InkPlugin,
 	leaf: WorkspaceLeaf,
 	file: TFile,
 	viewType: string,
 	svgString: string,
 	fileType: 'inkWriting' | 'inkDrawing',
+	onSettled: () => void,
 ) {
-	// Wait for the SVG view to be rendered
-	window.setTimeout(() => {
-		const view = leaf.view;
-		if (!view) return;
-
-		// Find the view container
-		const containerEl = view.containerEl;
-		if (!containerEl) return;
-
-		// Check if button already exists
-		if (containerEl.querySelector('.ddc_ink_svg-edit-button')) return;
-
-		// Find the view content area - Obsidian's SVG view typically uses .view-content
-		const viewContent = containerEl.querySelector('.view-content') ||
-			containerEl.querySelector('.markdown-source-view') ||
-			containerEl;
-
-		// Ensure the container has relative positioning for absolute button positioning
-		const computedStyle = window.getComputedStyle(viewContent);
-		if (computedStyle.position === 'static') {
-			viewContent.classList.add('ddc_ink_svg-view-content--anchor');
-		}
-
-		mountThemedNativeViewPreview(viewContent as HTMLElement, svgString, fileType);
-
-		// Create the button container
-		const buttonContainer = document.createElement('div');
-		buttonContainer.className = 'ddc_ink_svg-edit-button-container';
-
-		// Determine button text based on view type
-		const isDrawing = viewType.includes('drawing');
-		const buttonText = isDrawing ? 'Edit drawing' : 'Edit writing';
-
-		// Create the edit button
-		const editButton = document.createElement('button');
-		editButton.className = 'ddc_ink_btn-slim ddc_ink_svg-edit-button';
-		editButton.textContent = buttonText;
-		editButton.title = `Edit ${isDrawing ? 'drawing' : 'writing'} in custom view`;
-
-		// Handle button click
-		editButton.addEventListener('click', (e) => {
-			e.stopPropagation();
-			e.preventDefault();
-
-			void leaf.setViewState({
-				type: viewType,
-				state: { file: file.path },
-				active: true,
-			});
-		});
-
-		buttonContainer.appendChild(editButton);
-		viewContent.appendChild(buttonContainer);
-
-		// Clean up when the view changes
-		const cleanup = () => {
-			const existingButton = containerEl.querySelector('.ddc_ink_svg-edit-button-container');
-			if (existingButton) {
-				existingButton.remove();
+	scheduleNativeSvgChrome(
+		leaf,
+		(viewContent, containerEl) => {
+			if (containerEl.querySelector('.ddc_ink_svg-edit-button')) {
+				releaseNativeSvgFlashSuppression(leaf);
+				onSettled();
+				return;
 			}
-			const existingPreview = containerEl.querySelector(`.${THEMED_PREVIEW_HOST_CLASS}`);
-			if (existingPreview) {
-				existingPreview.remove();
-			}
-			containerEl.querySelectorAll('.ddc_ink_svg-native-media--hidden').forEach((el) => {
-				el.classList.remove('ddc_ink_svg-native-media--hidden');
-			});
-		};
 
-		// Register cleanup on file close
-		plugin.registerEvent(
-			plugin.app.workspace.on('file-open', () => {
-				// Clean up when a different file is opened
-				const currentView = leaf.view;
-				if (currentView instanceof FileView && currentView.file !== file) {
-					cleanup();
+			const computedStyle = window.getComputedStyle(viewContent);
+			if (computedStyle.position === 'static') {
+				viewContent.classList.add('ddc_ink_svg-view-content--anchor');
+			}
+
+			const didMountPreview = mountThemedNativeViewPreview(viewContent, svgString, fileType);
+			if (!didMountPreview) {
+				releaseNativeSvgFlashSuppression(leaf);
+				onSettled();
+				return;
+			}
+
+			const buttonContainer = document.createElement('div');
+			buttonContainer.className = 'ddc_ink_svg-edit-button-container';
+
+			const isDrawing = viewType.includes('drawing');
+			const buttonText = isDrawing ? 'Edit drawing' : 'Edit writing';
+
+			const editButton = document.createElement('button');
+			editButton.className = 'ddc_ink_btn-slim ddc_ink_svg-edit-button';
+			editButton.textContent = buttonText;
+			editButton.title = `Edit ${isDrawing ? 'drawing' : 'writing'} in custom view`;
+
+			editButton.addEventListener('click', (e) => {
+				e.stopPropagation();
+				e.preventDefault();
+
+				void leaf.setViewState({
+					type: viewType,
+					state: { file: file.path },
+					active: true,
+				});
+			});
+
+			buttonContainer.appendChild(editButton);
+			viewContent.appendChild(buttonContainer);
+
+			// Themed SVG is visible; native media stays display:none via --hidden.
+			releaseNativeSvgFlashSuppression(leaf);
+			onSettled();
+
+			const cleanup = () => {
+				const existingButton = containerEl.querySelector('.ddc_ink_svg-edit-button-container');
+				if (existingButton) {
+					existingButton.remove();
 				}
-			})
-		);
-	}, 100);
+				const existingPreview = containerEl.querySelector(`.${THEMED_PREVIEW_HOST_CLASS}`);
+				if (existingPreview) {
+					existingPreview.remove();
+				}
+				containerEl.querySelectorAll('.ddc_ink_svg-native-media--hidden').forEach((el) => {
+					el.classList.remove('ddc_ink_svg-native-media--hidden');
+				});
+				containerEl.classList.remove(AWAITING_THEME_CLASS);
+			};
+
+			plugin.registerEvent(
+				plugin.app.workspace.on('file-open', () => {
+					const currentView = leaf.view;
+					if (currentView instanceof FileView && currentView.file !== file) {
+						cleanup();
+					}
+				})
+			);
+		},
+		() => {
+			releaseNativeSvgFlashSuppression(leaf);
+			onSettled();
+		},
+	);
+}
+
+/**
+ * Run `onReady` as soon as the leaf's view content exists — no fixed delay that
+ * would let native media paint first.
+ */
+function scheduleNativeSvgChrome(
+	leaf: WorkspaceLeaf,
+	onReady: (viewContent: HTMLElement, containerEl: HTMLElement) => void,
+	onGiveUp: () => void,
+) {
+	let attempts = 0;
+
+	const tryMount = (): boolean => {
+		const view = leaf.view;
+		const containerEl = view?.containerEl;
+		if (!containerEl) return false;
+
+		const viewContent = (containerEl.querySelector('.view-content') ||
+			containerEl.querySelector('.markdown-source-view') ||
+			containerEl) as HTMLElement;
+
+		onReady(viewContent, containerEl);
+		return true;
+	};
+
+	if (tryMount()) return;
+
+	const tick = () => {
+		attempts += 1;
+		if (tryMount()) return;
+		if (attempts >= MAX_MOUNT_ATTEMPTS) {
+			onGiveUp();
+			return;
+		}
+		window.requestAnimationFrame(tick);
+	};
+	window.requestAnimationFrame(tick);
 }
 
 /**
  * Hide Obsidian's native img/object media and mount an inlined SVG under the
  * writing/drawing preview host class so ink-svg-preview-theme.scss applies.
+ * Returns false when inline mount fails so callers can restore native media.
  */
 function mountThemedNativeViewPreview(
 	viewContent: HTMLElement,
 	svgString: string,
 	fileType: 'inkWriting' | 'inkDrawing',
-) {
-	if (viewContent.querySelector(`.${THEMED_PREVIEW_HOST_CLASS}`)) return;
+): boolean {
+	if (viewContent.querySelector(`.${THEMED_PREVIEW_HOST_CLASS}`)) return true;
 
 	const nativeMedia = viewContent.querySelectorAll('img, object, embed');
 	nativeMedia.forEach((el) => {
@@ -122,14 +277,16 @@ function mountThemedNativeViewPreview(
 	});
 
 	const previewHost = document.createElement('div');
+	// Layout host + shared embed preview class: svg-edit-button.scss sizes the former;
+	// ink-svg-preview-theme.scss recolours paths via the latter (same as embeds/picker).
 	previewHost.className = `${THEMED_PREVIEW_HOST_CLASS} ${embedPreviewClassForFileType(fileType)}`;
 	if (!mountInlineSvgPreview(previewHost, svgString)) {
-		// Restore native media if inline mount fails so the leaf still shows something
 		nativeMedia.forEach((el) => {
 			el.classList.remove('ddc_ink_svg-native-media--hidden');
 		});
-		return;
+		return false;
 	}
 
 	viewContent.appendChild(previewHost);
+	return true;
 }

--- a/src/logic/utils/inline-svg-preview.ts
+++ b/src/logic/utils/inline-svg-preview.ts
@@ -15,6 +15,8 @@ export function embedPreviewClassForFileType(
 
 /**
  * Parse an SVG string and append the root element into `host` for CSS theme overrides.
+ * Callers must put writing/drawing embed preview classes on `host` (or an ancestor)
+ * so ink-svg-preview-theme.scss can override baked black fills — img/object cannot.
  * Returns true when an svg element was mounted.
  */
 export function mountInlineSvgPreview(host: HTMLElement, svgString: string): boolean {

--- a/src/logic/utils/svg-edit-button.scss
+++ b/src/logic/utils/svg-edit-button.scss
@@ -1,5 +1,29 @@
+@use '../../components/shared/ink-svg-preview-theme';
+
 .ddc_ink_svg-view-content--anchor {
     position: relative;
+}
+
+// Hide Obsidian's native SVG img/object once we mount a theme-aware inline preview.
+.ddc_ink_svg-native-media--hidden {
+    display: none !important;
+}
+
+.ddc_ink_svg-native-view-preview {
+    width: 100%;
+    height: 100%;
+    min-height: 12em;
+    overflow: auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    > svg {
+        max-width: 100%;
+        max-height: 100%;
+        width: auto;
+        height: auto;
+    }
 }
 
 .ddc_ink_svg-edit-button-container {

--- a/src/logic/utils/svg-edit-button.scss
+++ b/src/logic/utils/svg-edit-button.scss
@@ -4,6 +4,15 @@
     position: relative;
 }
 
+// Applied synchronously on file-open before vault.read so baked-black media never paints.
+.ddc_ink_svg-view--awaiting-theme {
+    img,
+    object,
+    embed {
+        visibility: hidden !important;
+    }
+}
+
 // Hide Obsidian's native SVG img/object once we mount a theme-aware inline preview.
 .ddc_ink_svg-native-media--hidden {
     display: none !important;


### PR DESCRIPTION
## Summary

- When opening an ink SVG in Obsidian’s native preview leaf (before Edit), the plugin now inlines the SVG under the shared writing/drawing preview host classes so theme stroke CSS applies.
- Native img/object media is hidden while the themed preview is mounted; Edit-button behaviour is unchanged.

## ClickUp

- [Svgs in dedicated views show as dark even in dark mode](https://app.clickup.com/t/86d3p7hyv) - `86d3p7hyv`

## Test plan

- [x] `npm run build` (tsc + esbuild)
- [ ] Open an ink writing SVG file in a leaf (not Edit mode) under dark theme — strokes should be light
- [ ] Same for a drawing SVG; confirm Edit button still switches into the custom editor

## Stack

Base: `release_0.5`
Depends on: none

Made with [Cursor](https://cursor.com)