### PR TITLE
feat: Faster insert-existing SVG picker

### DIFF
--- a/docs/copy-paste-embeds.md
+++ b/docs/copy-paste-embeds.md
@@ -84,7 +84,7 @@ Because the flag lives in the document itself, the decision prompt persists acro
 | Embed builder | `utils/build-embeds.ts` | Accepts `options.pendingPaste` and appends `&pendingPaste=true` to the URL |
 | URL parser | `utils/parse-settings-from-url.ts` | Returns `isPendingPaste: boolean` alongside `embedSettings` |
 | Paste handler | `utils/paste-embed-handler.ts` | Non-anchored global regex; injects `pendingPaste=true` into every embed found in clipboard text |
-| File picker utility | `src/logic/utils/open-ink-file-picker.ts` | Filters vault SVGs by ink file type, builds sectioned layout (Recent, On current page, Other), opens `SvgFilePickerModal`; shared by insert commands and the locate action |
+| File picker utility | `src/logic/utils/open-ink-file-picker.ts` | Opens the modal immediately, sniffs ink SVG types without full JSON parse, builds sectioned layout (Recent, On current page, Other); shared by insert commands and the locate action. See [Insert existing file picker](insert-existing-file-picker.md). |
 | CM6 widget (writing) | `writing-embed-extension.tsx` | Parses `isPendingPaste`, passes it, resolve callbacks, and `locateFile` to `WritingEmbed` |
 | CM6 widget (drawing) | `drawing-embed-extension.tsx` | Same for drawing |
 | React embed (writing) | `writing-embed.tsx` | When file is not found, always shows the not-found banner (with path + Locate button); when file is found and pending, shows the reference/duplicate banner above the preview |
@@ -120,9 +120,9 @@ When inserting an existing drawing or writing file (or when locating a missing f
 
 A file may appear in both Recent and On current page when it qualifies for both. The Other section excludes files that appear in either of the first two sections. Recent selections are persisted to `localStorage` and updated whenever the user chooses a file from the picker.
 
-Thumbnail previews use mtime-based cache busting (`?t=<mtime>`) on the image src so they stay current after edits. Without it, the browser would serve cached images for the same `getResourcePath` URL.
-
 A search input at the top filters visible results across all sections by matching the query against file basename or path (case-insensitive). When nothing matches, "No files match your search" is shown.
+
+For open latency, type sniffing, and lazy viewport previews on large vaults, see [Insert existing file picker](insert-existing-file-picker.md).
 
 ### Path scenarios covered by e2e tests
 

--- a/docs/insert-existing-file-picker.md
+++ b/docs/insert-existing-file-picker.md
@@ -1,0 +1,66 @@
+# Insert existing file picker
+
+## Why it exists
+
+Users need to pick an existing ink writing or drawing SVG from the vault (Insert existing… commands, and “Locate file” on a broken embed). A large vault can contain hundreds of SVGs, many of them large tldraw or ink-canvas files. Opening the picker must stay responsive: the modal should appear immediately, discovery should not parse every file’s full metadata JSON, and scrolling must not mount every preview DOM at once.
+
+## Conceptual understanding
+
+The picker is a modal with three sections (Recent, On current page, Other) and a fuzzy filename search. Internally it separates **discovery** (which vault SVGs are ink writing vs drawing) from **preview rendering** (mounting themed inline SVG for cards).
+
+```mermaid
+flowchart TB
+  openCmd[Insert existing / Locate file] --> openModal[Open modal with Scanning state]
+  openModal --> sniff[Concurrent cachedRead + sniffInkSvgFileType]
+  sniff --> sections[Build Recent / On page / Other]
+  sections --> cards[Render card shells with placeholders]
+  cards --> io[IntersectionObserver on sections scroller]
+  io -->|enters viewport| mount[Mount inline SVG preview]
+  io -->|leaves viewport| unload[Unload preview DOM keep string cache]
+```
+
+## Flows
+
+### Opening and discovery
+
+1. `openInkFilePicker` opens `SvgFilePickerModal` immediately with empty sections and `isScanning: true`.
+2. In the background it lists vault `.svg` files and classifies them with `collectMatchingInkSvgFiles` (bounded concurrency, default 8).
+3. Classification uses `sniffInkSvgFileType` — regex checks for ink markers and `file-type="inkWriting"|"inkDrawing"` — **not** `DOMParser` + `JSON.parse` of the embedded payload.
+4. When discovery finishes, `setSections` fills the grid and clears the scanning status. If the user already closed the modal, results are discarded (`hasClosed`).
+
+### Preview mounting while scrolling
+
+1. Each card starts with an empty placeholder.
+2. An `IntersectionObserver` (root = the sections scroller, with a small rootMargin) enqueues mount when a card intersects.
+3. At most four preview loads run at once so scrolling does not stampede `cachedRead` + `DOMParser`.
+4. Leaving the viewport unmounts the preview DOM but keeps the SVG string in a modal-lifetime cache so revisiting a card is cheap.
+5. Closing the modal clears the observer, pending queue, and string cache.
+
+### Manual QA (large vault)
+
+Regenerate the qa-test-vault (`node qa-test-vault/generate.mjs`), then use **19 – Insert Existing Picker**:
+
+- ~50 unique ink-canvas writing + ~50 drawing SVGs (`picker-stress-*.svg`)
+- Density note with ~60 unique embeds
+- Notes that exercise “other” vs “on current page” sections
+
+## Technical details
+
+| Piece | Location | Role |
+|---|---|---|
+| Open + discovery | `src/logic/utils/open-ink-file-picker.ts` | Immediate open, concurrent sniff, section build |
+| Cheap type check | `sniffInkSvgFileType` in `extractInkJsonFromSvg.ts` | Writing/drawing without full JSON parse |
+| Modal UI + lazy previews | `svg-picker-modal.ts` / `.scss` | Sections, search, IntersectionObserver queue |
+| Inline themed SVG | `mountInlineSvgPreview` in `inline-svg-preview.ts` | Parse SVG string into host for CSS theming |
+| Stress fixtures | `qa-test-vault/generate.mjs` → section 19 | Many current-format files for manual picker QA |
+
+Section layout (Recent / On current page / Other) and recent-path `localStorage` behaviour are also described under [Copy & paste embeds](copy-paste-embeds.md#insert-existing-file-modal).
+
+## Technical Gotchas
+
+- **Do not restore full `extractInkJsonFromSvg` in the discovery path** — large tldraw payloads make open latency scale with vault size. Sniff only.
+- **Writing vs drawing without `file-type`** — ink-canvas SVGs that lack `<ink file-type="…">` sniff as drawing (same default as format extraction). Stress fixtures always set `file-type` so both pickers stay populated.
+- **Unload vs cache** — unloading drops DOM only; the string cache is intentional so scroll-back does not re-read every file. The cache is cleared on modal close so edits on disk are visible next open (via a fresh `cachedRead`).
+- **`hasClosed` guards** — discovery and `setSections` must no-op after close so a late scan cannot resurrect UI on a disposed modal.
+- **Observer root** — the observer uses the sections scroller, not the window. Changing layout without updating `root` breaks unload and remount.
+- **QA vault is generated and mostly gitignored** — only `generate.mjs` and `README.md` are tracked; re-run the generator after pulling fixture changes.

--- a/qa-test-vault/README.md
+++ b/qa-test-vault/README.md
@@ -19,7 +19,7 @@ All Ink files (SVGs and legacy .writing/.drawing) are copied from real captured 
 
 - **01 – Basic Embeds**: Single, multiple, mixed, empty
 - **02 – Legacy Format**: v1 code block embeds (handwritten-ink, handdrawn-ink)
-- **03 – Density and Repetition**: Many embeds, same embed repeated, back-to-back
+- **03 – Density and Repetition**: Many unique ink-canvas embeds (~60), same embed repeated, back-to-back
 - **04 – Obsidian Native Features**: Block quotes, lists, tables, transclusion, headings, code blocks
 - **04b – Callouts and Layout**: Native callouts, Admonition, List Callouts, Columns (Multi-Column, Obsidian Columns, MCL)
 - **05 – Settings Variations**: writingLinesWhenLocked, drawingFrameWhenLocked, etc.
@@ -40,3 +40,4 @@ All Ink files (SVGs and legacy .writing/.drawing) are copied from real captured 
 - **16 – V2 Tldraw Migration**: Real v2 `<tldraw>` SVGs; preview, edit, upgrade to ink-canvas on save
 - **17 – Tldraw Bulk Migration**: Developer modal — bulk tldraw → ink-canvas in place
 - **18 – Captured Legacy Migration**: Real v1 .writing/.drawing captures from production vaults
+- **19 – Insert Existing Picker**: ~50 writing + ~50 drawing ink-canvas files for lazy-preview / large-vault picker QA

--- a/qa-test-vault/generate.mjs
+++ b/qa-test-vault/generate.mjs
@@ -211,7 +211,13 @@ function generateAllNotes() {
     ['02 - Legacy Format/V1 Writing Embed.md', `# V1 Writing\n${v1W}`],
     ['02 - Legacy Format/V1 Drawing Embed.md', `# V1 Drawing\n${v1D}`],
     ['02 - Legacy Format/V1 and V2 Side by Side.md', `# V1 and V2\n## V1 Writing\n${v1W}\n## V2 Writing\n${w('hello-world.svg')}\n## V1 Drawing\n${v1D}\n## V2 Drawing\n${d('simple-shape.svg')}`],
-    ['03 - Density and Repetition/Many Embeds on One Page.md', `# Many Embeds\n\n${[1,2,3,4,5,6].map(i => i%2?w('hello-world.svg'):d('simple-shape.svg')).join('\n\n')}\n\nEnd.`],
+    // ~10× the old 6-embed density note; unique ink-canvas files so Live Preview + picker "on current page" both stress.
+    ['03 - Density and Repetition/Many Embeds on One Page.md', `# Many Embeds\n\n${Array.from({ length: PICKER_STRESS_EMBED_COUNT }, (_, i) => {
+      const n = String(i + 1).padStart(2, '0');
+      return i % 2 === 0
+        ? w(`picker-stress-writing-${n}.svg`)
+        : d(`picker-stress-drawing-${n}.svg`, 500, 16 / 9, { x: 0, y: 0, w: 200, h: 120 });
+    }).join('\n\n')}\n\nEnd.`],
     ['03 - Density and Repetition/Same Embed Repeated.md', `# Same Repeated\n\n${w('hello-world.svg')}${w('hello-world.svg')}${w('hello-world.svg')}${w('hello-world.svg')}${w('hello-world.svg')}`],
     ['03 - Density and Repetition/Same Embed Across Pages Note A.md', `# Note A\n\n${d('simple-shape.svg')}\n\nSame in multiple notes.`],
     ['03 - Density and Repetition/Same Embed Across Pages Note B.md', `# Note B\n\n${d('simple-shape.svg')}\n\nSame in multiple notes.`],
@@ -474,7 +480,7 @@ All Ink files (SVGs and legacy .writing/.drawing) are copied from real captured 
 
 - **01 – Basic Embeds**: Single, multiple, mixed, empty
 - **02 – Legacy Format**: v1 code block embeds (handwritten-ink, handdrawn-ink)
-- **03 – Density and Repetition**: Many embeds, same embed repeated, back-to-back
+- **03 – Density and Repetition**: Many unique ink-canvas embeds (~60), same embed repeated, back-to-back
 - **04 – Obsidian Native Features**: Block quotes, lists, tables, transclusion, headings, code blocks
 - **04b – Callouts and Layout**: Native callouts, Admonition, List Callouts, Columns (Multi-Column, Obsidian Columns, MCL)
 - **05 – Settings Variations**: writingLinesWhenLocked, drawingFrameWhenLocked, etc.
@@ -495,6 +501,7 @@ All Ink files (SVGs and legacy .writing/.drawing) are copied from real captured 
 - **16 – V2 Tldraw Migration**: Real v2 \`<tldraw>\` SVGs; preview, edit, upgrade to ink-canvas on save
 - **17 – Tldraw Bulk Migration**: Developer modal — bulk tldraw → ink-canvas in place
 - **18 – Captured Legacy Migration**: Real v1 .writing/.drawing captures from production vaults
+- **19 – Insert Existing Picker**: ~50 writing + ~50 drawing ink-canvas files for lazy-preview / large-vault picker QA
 `);
   generateConversionTestAssets();
   generateMigrationTestAssets();
@@ -503,6 +510,7 @@ All Ink files (SVGs and legacy .writing/.drawing) are copied from real captured 
   generateV2TldrawMigrationAssets();
   generateTldrawBulkMigrationAssets();
   generateCapturedLegacyMigrationAssets();
+  generatePickerStressAssets();
 
   ensureDir('.obsidian');
   // Enable community plugins needed for column layout e2e tests.
@@ -1074,6 +1082,152 @@ Path scenarios (plugin × Obsidian settings):
 - **Subfolder/Deep Target.md** — nested target for depth test
 - **Relative Path Source.md** — relative path embed (../) — may break when pasted elsewhere
 - **Filename Only Embed.md** — filename only, ambiguous with OtherFolder/copy-paste-ambig.svg
+`);
+}
+
+// ─── Section 19: Insert-existing picker stress (many current ink-canvas files) ─
+// ~10× the handful of named current fixtures so Insert Existing can exercise sniffing,
+// sectioning, and lazy mount/unload of viewport previews on a large vault.
+
+/** Unique ink-canvas writing + drawing SVGs; also referenced by density / picker notes. */
+const PICKER_STRESS_FILE_COUNT = 50;
+/** Embeds on the density page (~10× the previous 6). */
+const PICKER_STRESS_EMBED_COUNT = 60;
+
+function buildPickerStressStrokeStyle() {
+  return {
+    size: 8,
+    thinning: 0.5,
+    smoothing: 0.5,
+    streamline: 0.5,
+    simulatePressure: true,
+    color: 'currentColor',
+  };
+}
+
+/**
+ * Compact ink-canvas SVG with visible stroke markup so picker previews are not blank.
+ * Index varies geometry so scrolling the picker shows distinct cards.
+ * Always sets file-type so sniffInkSvgFileType can classify writing vs drawing without JSON parse.
+ */
+function buildPickerStressInkCanvasSvg(fileType, index) {
+  const strokeId = `picker-stress-${fileType}-${index}`;
+  const isWriting = fileType === 'inkWriting';
+  // Distinct diagonal / scribble per index so lazy-loaded cards are visually different.
+  const x1 = 20 + (index % 10) * 8;
+  const y1 = 30 + (index % 7) * 6;
+  const x2 = 160 - (index % 9) * 5;
+  const y2 = 90 - (index % 5) * 4;
+  const midX = (x1 + x2) / 2;
+  const midY = y1 + ((index % 4) - 1.5) * 12;
+  const snapshot = {
+    version: 1,
+    strokes: [{
+      id: strokeId,
+      points: [[x1, y1, 0.5], [midX, midY, 0.6], [x2, y2, 0.5]],
+      style: buildPickerStressStrokeStyle(),
+      offset: { x: 0, y: 0 },
+    }],
+    gridEnabled: !isWriting,
+    ...(isWriting ? { writingLineHeight: 150 } : {}),
+  };
+  const viewBox = isWriting ? '0 0 2000 300' : '0 0 200 120';
+  const visibleMarkup = isWriting
+    ? [
+      `<line x1="100" y1="150" x2="1900" y2="150" stroke="#888888" stroke-opacity="0.5" class="ink-type-writing-line ink-color-writing-line" />`,
+      // Scale scribble into writing page space so embeds/previews show ink, not only guide lines.
+      `<path d="M${100 + x1 * 8},${120 + y1} L${100 + midX * 8},${120 + midY} L${100 + x2 * 8},${120 + y2}" fill="none" stroke="#000000" stroke-width="6" stroke-linecap="round" class="ink-type-stroke ink-color-primary" />`,
+    ].join('\n')
+    : `<path d="M${x1},${y1} L${midX},${midY} L${x2},${y2}" fill="none" stroke="#000000" stroke-width="4" stroke-linecap="round" class="ink-type-stroke ink-color-primary" />`;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox}">
+<metadata>
+<ink plugin-version="${PLUGIN_VERSION}" file-type="${fileType}"/>
+<ink-canvas version="${INK_CANVAS_FORMAT_VERSION}">${JSON.stringify(snapshot)}</ink-canvas>
+</metadata>
+${visibleMarkup}
+</svg>
+`;
+}
+
+function pickerStressFilename(kind, index) {
+  const n = String(index).padStart(2, '0');
+  return kind === 'writing'
+    ? `picker-stress-writing-${n}.svg`
+    : `picker-stress-drawing-${n}.svg`;
+}
+
+function generatePickerStressAssets() {
+  ensureDir(path.join(VAULT_ROOT, 'Ink/Writing'));
+  ensureDir(path.join(VAULT_ROOT, 'Ink/Drawing'));
+  ensureDir(path.join(VAULT_ROOT, '19 - Insert Existing Picker'));
+
+  for (let i = 1; i <= PICKER_STRESS_FILE_COUNT; i++) {
+    const writingName = pickerStressFilename('writing', i);
+    const drawingName = pickerStressFilename('drawing', i);
+    fs.writeFileSync(
+      path.join(VAULT_ROOT, 'Ink/Writing', writingName),
+      buildPickerStressInkCanvasSvg('inkWriting', i),
+      'utf8',
+    );
+    fs.writeFileSync(
+      path.join(VAULT_ROOT, 'Ink/Drawing', drawingName),
+      buildPickerStressInkCanvasSvg('inkDrawing', i),
+      'utf8',
+    );
+  }
+
+  const writingEmbeds = Array.from({ length: PICKER_STRESS_FILE_COUNT }, (_, i) =>
+    buildWritingEmbed(`Ink/Writing/${pickerStressFilename('writing', i + 1)}`)).join('\n');
+  const drawingEmbeds = Array.from({ length: PICKER_STRESS_FILE_COUNT }, (_, i) =>
+    buildDrawingEmbed(
+      `Ink/Drawing/${pickerStressFilename('drawing', i + 1)}`,
+      500,
+      16 / 9,
+      { x: 0, y: 0, w: 200, h: 120 },
+    )).join('\n');
+
+  writeFile('19 - Insert Existing Picker/README.md', `# Insert Existing Picker
+
+Stress fixtures for **Insert existing writing/drawing** (lazy SVG previews, sniff without full JSON parse).
+
+## What was generated
+
+- \`${PICKER_STRESS_FILE_COUNT}\` unique **ink-canvas** writing SVGs: \`Ink/Writing/picker-stress-writing-01.svg\` … \`-${String(PICKER_STRESS_FILE_COUNT).padStart(2, '0')}.svg\`
+- \`${PICKER_STRESS_FILE_COUNT}\` unique **ink-canvas** drawing SVGs: \`Ink/Drawing/picker-stress-drawing-01.svg\` … \`-${String(PICKER_STRESS_FILE_COUNT).padStart(2, '0')}.svg\`
+- Density note \`03 - Density and Repetition/Many Embeds on One Page.md\` embeds ${PICKER_STRESS_EMBED_COUNT} of these (mixed writing/drawing)
+
+## How to test
+
+1. Open **All Writing Files Embed.md** or a blank note → command **Insert existing writing**.
+2. Confirm the picker opens quickly, lists many files, and only mounts previews near the viewport while scrolling.
+3. Repeat with **Insert existing drawing** from **All Drawing Files Embed.md**.
+4. From **On Current Page Writing.md**, open the writing picker and confirm an **On this page** (or equivalent) section lists the embeds from that note.
+`);
+
+  writeFile('19 - Insert Existing Picker/All Writing Files Embed.md', `# All Writing Files Embed
+
+All ${PICKER_STRESS_FILE_COUNT} picker-stress writing files embedded (scroll the note; use Insert existing writing to see the full vault list).
+
+${writingEmbeds}
+`);
+
+  writeFile('19 - Insert Existing Picker/All Drawing Files Embed.md', `# All Drawing Files Embed
+
+All ${PICKER_STRESS_FILE_COUNT} picker-stress drawing files embedded.
+
+${drawingEmbeds}
+`);
+
+  // Subset on one note so "on current page" has a non-trivial section without embedding the entire set twice.
+  const onPageCount = 20;
+  const onPageWriting = Array.from({ length: onPageCount }, (_, i) =>
+    buildWritingEmbed(`Ink/Writing/${pickerStressFilename('writing', i + 1)}`)).join('\n');
+  writeFile('19 - Insert Existing Picker/On Current Page Writing.md', `# On Current Page Writing
+
+Embeds the first ${onPageCount} picker-stress writing files. Open **Insert existing writing** from this note to exercise the on-current-page section vs the rest of the vault.
+
+${onPageWriting}
 `);
 }
 

--- a/src/components/dom-components/modals/svg-picker-modal/svg-picker-modal.scss
+++ b/src/components/dom-components/modals/svg-picker-modal/svg-picker-modal.scss
@@ -141,3 +141,16 @@
 .ink-svg-picker-search {
 	margin-bottom: 8px;
 }
+
+.ink-svg-picker-status {
+	margin-bottom: 8px;
+	font-size: 12px;
+	color: var(--text-muted);
+}
+
+.ink-svg-picker-sections {
+	// Dedicated scroller so IntersectionObserver can mount/unload off-screen previews.
+	max-height: min(70vh, 36em);
+	overflow: auto;
+	padding-right: 2px;
+}

--- a/src/components/dom-components/modals/svg-picker-modal/svg-picker-modal.ts
+++ b/src/components/dom-components/modals/svg-picker-modal/svg-picker-modal.ts
@@ -9,6 +9,10 @@ import {
 ////////
 ////////
 
+/** Cap concurrent SVG parses so scrolling does not stampede vault reads + DOMParser. */
+const MAX_CONCURRENT_PREVIEW_LOADS = 4;
+const PREVIEW_ROOT_MARGIN = "120px 0px";
+
 function fileMatchesQuery(file: TFile, query: string): boolean {
 	const trimmed = query.trim();
 	if (trimmed === "") return true;
@@ -20,13 +24,30 @@ function filterFiles(files: TFile[], query: string): TFile[] {
 	return files.filter((file) => fileMatchesQuery(file, query));
 }
 
+type CardPreviewState = {
+	file: TFile;
+	previewHost: HTMLElement;
+	isMounted: boolean;
+	loadGeneration: number;
+};
+
 export class SvgFilePickerModal extends Modal {
 	titleText: string;
 	sections: SectionedFiles;
 	fileType: "inkWriting" | "inkDrawing";
 	onChoose: (file: TFile) => void;
 	searchQuery = "";
+	/** True after onClose — discovery must not refresh a dismissed modal. */
+	hasClosed = false;
+	private isScanning = false;
 	private svgContentCache = new Map<string, string>();
+	private previewObserver: IntersectionObserver | null = null;
+	private cardPreviewStates = new Map<HTMLElement, CardPreviewState>();
+	private activePreviewLoads = 0;
+	private pendingPreviewLoads: CardPreviewState[] = [];
+	private searchComponent: SearchComponent | null = null;
+	private sectionsContainer: HTMLElement | null = null;
+	private statusEl: HTMLElement | null = null;
 
 	constructor(
 		app: App,
@@ -35,6 +56,7 @@ export class SvgFilePickerModal extends Modal {
 			sections: SectionedFiles;
 			fileType: "inkWriting" | "inkDrawing";
 			onChoose: (file: TFile) => void;
+			isScanning?: boolean;
 		}
 	) {
 		super(app);
@@ -42,24 +64,124 @@ export class SvgFilePickerModal extends Modal {
 		this.sections = options.sections;
 		this.fileType = options.fileType;
 		this.onChoose = options.onChoose;
+		this.isScanning = options.isScanning === true;
 	}
 
-	private async loadInlinePreview(previewHost: HTMLElement, file: TFile): Promise<void> {
+	/**
+	 * Replace sectioned files after async discovery finishes (or streams updates).
+	 * Re-renders the filtered grid while keeping the search query.
+	 */
+	setSections(sections: SectionedFiles, isScanning: boolean) {
+		if (this.hasClosed) return;
+		this.sections = sections;
+		this.isScanning = isScanning;
+		this.updateStatusText();
+		this.applyFilter();
+	}
+
+	private updateStatusText() {
+		if (!this.statusEl) return;
+		if (this.isScanning) {
+			this.statusEl.setText("Scanning vault for ink files…");
+			this.statusEl.show();
+			return;
+		}
+		this.statusEl.hide();
+	}
+
+	private disconnectPreviewObserver() {
+		this.previewObserver?.disconnect();
+		this.previewObserver = null;
+		this.cardPreviewStates.clear();
+		this.pendingPreviewLoads = [];
+		this.activePreviewLoads = 0;
+	}
+
+	private ensurePreviewObserver() {
+		if (this.previewObserver || !this.sectionsContainer) return;
+		// Observe against the sections scroller so off-screen grid cards unload.
+		this.previewObserver = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					const state = this.cardPreviewStates.get(entry.target as HTMLElement);
+					if (!state) continue;
+					if (entry.isIntersecting) {
+						this.enqueuePreviewMount(state);
+					} else if (state.isMounted) {
+						this.unloadPreview(state);
+					}
+				}
+			},
+			{
+				root: this.sectionsContainer,
+				rootMargin: PREVIEW_ROOT_MARGIN,
+				threshold: 0.01,
+			},
+		);
+	}
+
+	private enqueuePreviewMount(state: CardPreviewState) {
+		if (state.isMounted) return;
+		if (this.pendingPreviewLoads.includes(state)) return;
+		this.pendingPreviewLoads.push(state);
+		this.pumpPreviewLoadQueue();
+	}
+
+	private pumpPreviewLoadQueue() {
+		while (
+			this.activePreviewLoads < MAX_CONCURRENT_PREVIEW_LOADS
+			&& this.pendingPreviewLoads.length > 0
+		) {
+			const next = this.pendingPreviewLoads.shift();
+			if (!next) break;
+			if (next.isMounted) continue;
+			this.activePreviewLoads++;
+			void this.loadInlinePreview(next).finally(() => {
+				this.activePreviewLoads = Math.max(0, this.activePreviewLoads - 1);
+				this.pumpPreviewLoadQueue();
+			});
+		}
+	}
+
+	private unloadPreview(state: CardPreviewState) {
+		// Keep string cache; drop DOM so off-screen complex SVGs do not stay mounted.
+		state.loadGeneration++;
+		state.isMounted = false;
+		state.previewHost.empty();
+		state.previewHost.createDiv({
+			cls: "ink-svg-picker-preview-placeholder",
+			text: "",
+		});
+	}
+
+	private async loadInlinePreview(state: CardPreviewState): Promise<void> {
+		const generation = ++state.loadGeneration;
+		const { previewHost, file } = state;
 		try {
 			let svgString = this.svgContentCache.get(file.path);
 			if (svgString === undefined) {
-				svgString = await this.app.vault.read(file);
+				svgString = await this.app.vault.cachedRead(file);
 				this.svgContentCache.set(file.path, svgString);
 			}
-			if (mountInlineSvgPreview(previewHost, svgString)) return;
+			// Card may have scrolled out or been re-rendered while we awaited
+			if (generation !== state.loadGeneration) return;
+			if (![...this.cardPreviewStates.values()].includes(state)) return;
+
+			if (mountInlineSvgPreview(previewHost, svgString)) {
+				state.isMounted = true;
+				return;
+			}
 		} catch {
 			// fall through to placeholder
 		}
+		if (generation !== state.loadGeneration) return;
+		if (![...this.cardPreviewStates.values()].includes(state)) return;
 		previewHost.empty();
 		previewHost.createDiv({
 			cls: "ink-svg-picker-preview-placeholder",
 			text: "Preview unavailable",
 		});
+		state.isMounted = true;
 	}
 
 	private createFileCard(container: HTMLElement, file: TFile, isHorizontalRow = false): void {
@@ -73,7 +195,20 @@ export class SvgFilePickerModal extends Modal {
 		const previewHost = previewWrapper.createDiv({
 			cls: embedPreviewClassForFileType(this.fileType),
 		});
-		void this.loadInlinePreview(previewHost, file);
+		// Placeholder until the card intersects the scroll viewport
+		previewHost.createDiv({
+			cls: "ink-svg-picker-preview-placeholder",
+			text: "",
+		});
+
+		const state: CardPreviewState = {
+			file,
+			previewHost,
+			isMounted: false,
+			loadGeneration: 0,
+		};
+		this.cardPreviewStates.set(card, state);
+		this.previewObserver?.observe(card);
 
 		const label = card.createDiv({ cls: "ink-svg-picker-label" });
 		label.setText(file.basename);
@@ -142,7 +277,10 @@ export class SvgFilePickerModal extends Modal {
 	}
 
 	private renderSections(container: HTMLElement, filteredRecent: TFile[], filteredOnPage: TFile[], filteredOther: TFile[]): void {
+		this.disconnectPreviewObserver();
 		container.empty();
+		this.ensurePreviewObserver();
+
 		const otherLabel =
 			this.fileType === "inkDrawing" ? "Other drawings" : "Other writing";
 		const recentLabel =
@@ -151,7 +289,7 @@ export class SvgFilePickerModal extends Modal {
 		const hasAnyResults = filteredRecent.length > 0 || filteredOnPage.length > 0 || filteredOther.length > 0;
 		if (!hasAnyResults) {
 			const emptyEl = container.createDiv({ cls: "ink-svg-picker-empty" });
-			emptyEl.setText("No files match your search");
+			emptyEl.setText(this.isScanning ? "Scanning vault…" : "No files match your search");
 			return;
 		}
 
@@ -175,36 +313,45 @@ export class SvgFilePickerModal extends Modal {
 		}
 	}
 
+	private applyFilter() {
+		if (!this.sectionsContainer || !this.searchComponent) return;
+		this.searchQuery = this.searchComponent.getValue();
+		const filteredRecent = filterFiles(this.sections.recent, this.searchQuery);
+		const filteredOnPage = filterFiles(this.sections.onCurrentPage, this.searchQuery);
+		const filteredOther = filterFiles(this.sections.other, this.searchQuery);
+		this.renderSections(this.sectionsContainer, filteredRecent, filteredOnPage, filteredOther);
+	}
+
 	onOpen() {
 		const { titleEl, contentEl } = this;
 		titleEl.setText(this.titleText);
 
+		this.statusEl = contentEl.createDiv({ cls: "ink-svg-picker-status" });
+		this.updateStatusText();
+
 		const searchContainer = contentEl.createDiv({ cls: "ink-svg-picker-search" });
-		const searchComponent = new SearchComponent(searchContainer);
-		searchComponent.setPlaceholder("Search by filename...");
-		searchComponent.setValue(this.searchQuery);
+		this.searchComponent = new SearchComponent(searchContainer);
+		this.searchComponent.setPlaceholder("Search by filename...");
+		this.searchComponent.setValue(this.searchQuery);
 
-		const sectionsContainer = contentEl.createDiv({ cls: "ink-svg-picker-sections" });
+		this.sectionsContainer = contentEl.createDiv({ cls: "ink-svg-picker-sections" });
 
-		const applyFilter = () => {
-			this.searchQuery = searchComponent.getValue();
-			const filteredRecent = filterFiles(this.sections.recent, this.searchQuery);
-			const filteredOnPage = filterFiles(this.sections.onCurrentPage, this.searchQuery);
-			const filteredOther = filterFiles(this.sections.other, this.searchQuery);
-			this.renderSections(sectionsContainer, filteredRecent, filteredOnPage, filteredOther);
-		};
+		this.searchComponent.onChange(() => this.applyFilter());
 
-		searchComponent.onChange(applyFilter);
-
-		applyFilter();
+		this.applyFilter();
 
 		window.requestAnimationFrame(() => {
-			searchComponent.inputEl.focus();
+			this.searchComponent?.inputEl.focus();
 		});
 	}
 
 	onClose() {
+		this.hasClosed = true;
+		this.disconnectPreviewObserver();
 		this.svgContentCache.clear();
+		this.searchComponent = null;
+		this.sectionsContainer = null;
+		this.statusEl = null;
 		this.contentEl.empty();
 	}
 }

--- a/src/components/dom-components/modals/svg-picker-modal/svg-picker-modal.ts
+++ b/src/components/dom-components/modals/svg-picker-modal/svg-picker-modal.ts
@@ -11,6 +11,7 @@ import {
 
 /** Cap concurrent SVG parses so scrolling does not stampede vault reads + DOMParser. */
 const MAX_CONCURRENT_PREVIEW_LOADS = 4;
+/** Prefetch slightly outside the scroller so fast scrolls still feel continuous. */
 const PREVIEW_ROOT_MARGIN = "120px 0px";
 
 function fileMatchesQuery(file: TFile, query: string): boolean {

--- a/src/logic/utils/extractInkJsonFromSvg.ts
+++ b/src/logic/utils/extractInkJsonFromSvg.ts
@@ -7,6 +7,32 @@ import type { InkCanvasSnapshot } from 'src/ink-canvas/types';
 /////////////////////
 
 /**
+ * Cheap file-type check for picker discovery — avoids DOMParser + JSON.parse of large
+ * tldraw/ink-canvas payloads when we only need to know writing vs drawing.
+ * Returns null when the SVG does not look like an Ink attachment of a single known type.
+ */
+export function sniffInkSvgFileType(svgString: string): 'inkWriting' | 'inkDrawing' | null {
+	const trimmedStart = svgString.trimStart();
+	if (!trimmedStart.startsWith('<')) return null;
+
+	const hasInkMarker =
+		/<ink[\s>]/i.test(svgString)
+		|| /<ink-canvas[\s>]/i.test(svgString)
+		|| /<tldraw[\s>]/i.test(svgString);
+	if (!hasInkMarker) return null;
+
+	const isWriting = /file-type\s*=\s*["']inkWriting["']/i.test(svgString);
+	const isDrawing = /file-type\s*=\s*["']inkDrawing["']/i.test(svgString);
+	if (isWriting && !isDrawing) return 'inkWriting';
+	if (isDrawing && !isWriting) return 'inkDrawing';
+	// Match extractInkCanvasFormat: ink-canvas without file-type defaults to drawing
+	if (!isWriting && !isDrawing && /<ink-canvas[\s>]/i.test(svgString)) {
+		return 'inkDrawing';
+	}
+	return null;
+}
+
+/**
  * Extracts JSON content from SVG metadata.
  * Supports two metadata formats:
  * - `<ink-canvas version="…">` — ink-canvas engine (`inkCanvas` snapshot)

--- a/src/logic/utils/open-ink-file-picker.ts
+++ b/src/logic/utils/open-ink-file-picker.ts
@@ -1,6 +1,6 @@
 import { MarkdownView, Notice, normalizePath, TFile } from "obsidian";
 import InkPlugin from "src/main";
-import { extractInkJsonFromSvg } from "src/logic/utils/extractInkJsonFromSvg";
+import { sniffInkSvgFileType } from "src/logic/utils/extractInkJsonFromSvg";
 import { SvgFilePickerModal } from "src/components/dom-components/modals/svg-picker-modal/svg-picker-modal";
 import { fetchRecentFilePaths, recordRecentFileSelection } from "src/logic/utils/storage";
 import { findNotesContainingFileEmbed } from "src/logic/utils/convert-file-embeds";
@@ -10,206 +10,242 @@ import { verbose } from "src/logic/utils/universal-dev-logging";
 ////////
 
 export type SectionedFiles = {
-    recent: TFile[];
-    onCurrentPage: TFile[];
-    other: TFile[];
+	recent: TFile[];
+	onCurrentPage: TFile[];
+	other: TFile[];
 };
 
 const EMBED_PATH_REGEX = /!\[(InkWriting|InkDrawing)\]\(<([^>]+)>\)/g;
 const RECENT_MAX = 10;
+/** Parallel vault reads during type sniff — keeps open latency down without stampeding I/O. */
+const DISCOVERY_READ_CONCURRENCY = 8;
 
 function extractEmbedPathsFromNote(
-    content: string,
-    fileType: 'inkWriting' | 'inkDrawing'
+	content: string,
+	fileType: 'inkWriting' | 'inkDrawing'
 ): string[] {
-    const altText = fileType === 'inkWriting' ? 'InkWriting' : 'InkDrawing';
-    const paths: string[] = [];
-    let match: RegExpExecArray | null;
-    EMBED_PATH_REGEX.lastIndex = 0;
-    while ((match = EMBED_PATH_REGEX.exec(content)) !== null) {
-        if (match[1] === altText) paths.push(match[2].trim());
-    }
-    return paths;
+	const altText = fileType === 'inkWriting' ? 'InkWriting' : 'InkDrawing';
+	const paths: string[] = [];
+	let match: RegExpExecArray | null;
+	EMBED_PATH_REGEX.lastIndex = 0;
+	while ((match = EMBED_PATH_REGEX.exec(content)) !== null) {
+		if (match[1] === altText) paths.push(match[2].trim());
+	}
+	return paths;
 }
 
 function resolvePathToCanonical(
-    vault: { getAbstractFileByPath: (path: string) => unknown },
-    metadataCache: { getFirstLinkpathDest: (linkpath: string, sourcePath: string) => TFile | null },
-    linkpath: string,
-    sourcePath: string
+	vault: { getAbstractFileByPath: (path: string) => unknown },
+	metadataCache: { getFirstLinkpathDest: (linkpath: string, sourcePath: string) => TFile | null },
+	linkpath: string,
+	sourcePath: string
 ): string | null {
-    const normalized = normalizePath(linkpath);
-    const resolved = metadataCache.getFirstLinkpathDest(normalized, sourcePath);
-    if (resolved instanceof TFile) return resolved.path;
-    const byPath = vault.getAbstractFileByPath(normalized);
-    if (byPath instanceof TFile) return byPath.path;
-    return null;
+	const normalized = normalizePath(linkpath);
+	const resolved = metadataCache.getFirstLinkpathDest(normalized, sourcePath);
+	if (resolved instanceof TFile) return resolved.path;
+	const byPath = vault.getAbstractFileByPath(normalized);
+	if (byPath instanceof TFile) return byPath.path;
+	return null;
 }
 
 async function getNoteForOnCurrentPage(
-    plugin: InkPlugin,
-    fileType: 'inkWriting' | 'inkDrawing',
-    sourceFile: TFile | null
+	plugin: InkPlugin,
+	fileType: 'inkWriting' | 'inkDrawing',
+	sourceFile: TFile | null
 ): Promise<TFile | null> {
-    if (!sourceFile) return null;
-    if (sourceFile.extension === "md") return sourceFile;
-    if (sourceFile.extension === "svg") {
-        const notes = await findNotesContainingFileEmbed(
-            plugin.app.vault,
-            sourceFile.path,
-            fileType
-        );
-        return notes[0] ?? null;
-    }
-    return null;
+	if (!sourceFile) return null;
+	if (sourceFile.extension === "md") return sourceFile;
+	if (sourceFile.extension === "svg") {
+		const notes = await findNotesContainingFileEmbed(
+			plugin.app.vault,
+			sourceFile.path,
+			fileType
+		);
+		return notes[0] ?? null;
+	}
+	return null;
 }
 
 async function buildSectionedFiles(
-    plugin: InkPlugin,
-    validFiles: TFile[],
-    fileType: 'inkWriting' | 'inkDrawing',
-    sourceFile: TFile | null,
-    noteContent: string | null
+	plugin: InkPlugin,
+	validFiles: TFile[],
+	fileType: 'inkWriting' | 'inkDrawing',
+	sourceFile: TFile | null,
+	noteContent: string | null
 ): Promise<SectionedFiles> {
-    const validByPath = new Map<string, TFile>();
-    for (const file of validFiles) {
-        validByPath.set(file.path, file);
-    }
+	const validByPath = new Map<string, TFile>();
+	for (const file of validFiles) {
+		validByPath.set(file.path, file);
+	}
 
-    const recentPaths = fetchRecentFilePaths(fileType).slice(0, RECENT_MAX);
-    const recent: TFile[] = [];
-    const recentPathsSeen = new Set<string>();
-    for (const path of recentPaths) {
-        const file = validByPath.get(path);
-        if (file && !recentPathsSeen.has(path)) {
-            recent.push(file);
-            recentPathsSeen.add(path);
-        }
-    }
+	const recentPaths = fetchRecentFilePaths(fileType).slice(0, RECENT_MAX);
+	const recent: TFile[] = [];
+	const recentPathsSeen = new Set<string>();
+	for (const path of recentPaths) {
+		const file = validByPath.get(path);
+		if (file && !recentPathsSeen.has(path)) {
+			recent.push(file);
+			recentPathsSeen.add(path);
+		}
+	}
 
-    const onPagePathsSeen = new Set<string>();
-    const onCurrentPage: TFile[] = [];
-    const noteFile = await getNoteForOnCurrentPage(plugin, fileType, sourceFile);
+	const onPagePathsSeen = new Set<string>();
+	const onCurrentPage: TFile[] = [];
+	const noteFile = await getNoteForOnCurrentPage(plugin, fileType, sourceFile);
 
-    verbose(["[On Current Page] getNoteForOnCurrentPage", {
-        noteFile: noteFile?.path ?? null,
-        sourceWasSvg: sourceFile?.extension === "svg",
-    }]);
+	verbose(["[On Current Page] getNoteForOnCurrentPage", {
+		noteFile: noteFile?.path ?? null,
+		sourceWasSvg: sourceFile?.extension === "svg",
+	}]);
 
-    if (noteFile) {
-        const content = noteContent ?? (await plugin.app.vault.cachedRead(noteFile));
+	if (noteFile) {
+		const content = noteContent ?? (await plugin.app.vault.cachedRead(noteFile));
 
-        verbose(["[On Current Page] content", {
-            contentLength: content.length,
-            containsInkDrawing: content.includes("InkDrawing"),
-            containsInkWriting: content.includes("InkWriting"),
-        }]);
+		verbose(["[On Current Page] content", {
+			contentLength: content.length,
+			containsInkDrawing: content.includes("InkDrawing"),
+			containsInkWriting: content.includes("InkWriting"),
+		}]);
 
-        const rawPaths = extractEmbedPathsFromNote(content, fileType);
+		const rawPaths = extractEmbedPathsFromNote(content, fileType);
 
-        verbose(["[On Current Page] extractEmbedPathsFromNote", {
-            rawPaths,
-            count: rawPaths.length,
-        }]);
+		verbose(["[On Current Page] extractEmbedPathsFromNote", {
+			rawPaths,
+			count: rawPaths.length,
+		}]);
 
-        for (const linkpath of rawPaths) {
-            const canonical = resolvePathToCanonical(
-                plugin.app.vault,
-                plugin.app.metadataCache,
-                linkpath,
-                noteFile.path
-            );
-            const inValidByPath = canonical !== null && validByPath.has(canonical);
-            const inRecentPathsSeen = canonical !== null && recentPathsSeen.has(canonical);
+		for (const linkpath of rawPaths) {
+			const canonical = resolvePathToCanonical(
+				plugin.app.vault,
+				plugin.app.metadataCache,
+				linkpath,
+				noteFile.path
+			);
+			const inValidByPath = canonical !== null && validByPath.has(canonical);
+			const inRecentPathsSeen = canonical !== null && recentPathsSeen.has(canonical);
 
-            verbose(["[On Current Page] resolvePath", {
-                linkpath,
-                canonical,
-                inValidByPath,
-                inRecentPathsSeen,
-            }]);
+			verbose(["[On Current Page] resolvePath", {
+				linkpath,
+				canonical,
+				inValidByPath,
+				inRecentPathsSeen,
+			}]);
 
-            if (canonical && inValidByPath && !onPagePathsSeen.has(canonical)) {
-                const file = validByPath.get(canonical)!;
-                onCurrentPage.push(file);
-                onPagePathsSeen.add(canonical);
-            }
-        }
-    }
+			if (canonical && inValidByPath && !onPagePathsSeen.has(canonical)) {
+				const file = validByPath.get(canonical)!;
+				onCurrentPage.push(file);
+				onPagePathsSeen.add(canonical);
+			}
+		}
+	}
 
-    verbose(["[On Current Page] result", { onCurrentPageCount: onCurrentPage.length }]);
+	verbose(["[On Current Page] result", { onCurrentPageCount: onCurrentPage.length }]);
 
-    const shownPaths = new Set([...recentPathsSeen, ...onPagePathsSeen]);
-    const other: TFile[] = validFiles.filter(file => !shownPaths.has(file.path));
+	const shownPaths = new Set([...recentPathsSeen, ...onPagePathsSeen]);
+	const other: TFile[] = validFiles.filter(file => !shownPaths.has(file.path));
 
-    return { recent, onCurrentPage, other };
+	return { recent, onCurrentPage, other };
+}
+
+/**
+ * Read and sniff SVG file types with bounded concurrency so picker open does not
+ * wait on a long sequential vault.read + full JSON parse chain.
+ */
+async function collectMatchingInkSvgFiles(
+	plugin: InkPlugin,
+	svgFiles: TFile[],
+	fileType: 'inkWriting' | 'inkDrawing',
+): Promise<TFile[]> {
+	const validFiles: TFile[] = [];
+	let nextIndex = 0;
+
+	const workerCount = Math.min(DISCOVERY_READ_CONCURRENCY, Math.max(1, svgFiles.length));
+	const workers = Array.from({ length: workerCount }, async () => {
+		while (nextIndex < svgFiles.length) {
+			const fileIndex = nextIndex++;
+			const file = svgFiles[fileIndex];
+			try {
+				const svgString = await plugin.app.vault.cachedRead(file);
+				if (sniffInkSvgFileType(svgString) === fileType) {
+					validFiles.push(file);
+				}
+			} catch {
+				// ignore invalid/unreadable files
+			}
+		}
+	});
+
+	await Promise.all(workers);
+	validFiles.sort((a, b) => a.path.localeCompare(b.path));
+	return validFiles;
 }
 
 export type OpenInkFilePickerOptions = {
-    sourceFile?: TFile | null;
-    /** When provided, used for On current page parsing instead of reading from vault (avoids stale cache for unsaved edits). */
-    noteContent?: string;
+	sourceFile?: TFile | null;
+	/** When provided, used for On current page parsing instead of reading from vault (avoids stale cache for unsaved edits). */
+	noteContent?: string;
 };
 
 export async function openInkFilePicker(
-    plugin: InkPlugin,
-    fileType: 'inkWriting' | 'inkDrawing',
-    title: string,
-    onChoose: (file: TFile) => void | Promise<void>,
-    options?: OpenInkFilePickerOptions
+	plugin: InkPlugin,
+	fileType: 'inkWriting' | 'inkDrawing',
+	title: string,
+	onChoose: (file: TFile) => void | Promise<void>,
+	options?: OpenInkFilePickerOptions
 ): Promise<void> {
-    const allFiles = plugin.app.vault.getFiles();
-    const svgFiles = allFiles.filter(file => file.extension === 'svg');
-    const validFiles: TFile[] = [];
+	const allFiles = plugin.app.vault.getFiles();
+	const svgFiles = allFiles.filter(file => file.extension === 'svg');
 
-    for (let i = 0; i < svgFiles.length; i++) {
-        const file = svgFiles[i];
-        try {
-            const svgString = await plugin.app.vault.read(file);
-            if (!svgString || !svgString.trim().startsWith('<svg')) continue;
-            const inkFileData = extractInkJsonFromSvg(svgString);
-            if (!inkFileData) continue;
-            if (inkFileData.meta.fileType === fileType) validFiles.push(file);
-        } catch (_) {
-            // ignore invalid/unreadable files
-        }
-    }
+	const fileTypeLabel = fileType === 'inkWriting' ? 'writing' : 'drawing';
+	if (svgFiles.length === 0) {
+		new Notice(`No ${fileTypeLabel} SVGs found`);
+		return;
+	}
 
-    const fileTypeLabel = fileType === 'inkWriting' ? 'writing' : 'drawing';
-    if (validFiles.length === 0) {
-        new Notice(`No ${fileTypeLabel} SVGs found`);
-        return;
-    }
+	const effectiveSource =
+		options?.sourceFile ??
+		plugin.app.workspace.getActiveViewOfType(MarkdownView)?.file ??
+		plugin.app.workspace.getActiveFile();
 
-    const effectiveSource =
-        options?.sourceFile ??
-        plugin.app.workspace.getActiveViewOfType(MarkdownView)?.file ??
-        plugin.app.workspace.getActiveFile();
+	const noteContent = options?.noteContent ?? null;
 
-    const noteContent = options?.noteContent ?? null;
+	verbose(["[On Current Page] effectiveSource", {
+		effectiveSource: effectiveSource?.path ?? null,
+		hasNoteContent: noteContent !== null,
+	}]);
 
-    verbose(["[On Current Page] effectiveSource", {
-        effectiveSource: effectiveSource?.path ?? null,
-        hasNoteContent: noteContent !== null,
-    }]);
+	const wrappedOnChoose = (file: TFile) => {
+		recordRecentFileSelection(fileType, file.path);
+		void Promise.resolve(onChoose(file));
+	};
 
-    const sections = await buildSectionedFiles(
-        plugin,
-        validFiles,
-        fileType,
-        effectiveSource ?? null,
-        noteContent
-    );
+	// Open immediately with a scanning state so the user is not blocked on full vault sniff.
+	const modal = new SvgFilePickerModal(plugin.app, {
+		title,
+		sections: { recent: [], onCurrentPage: [], other: [] },
+		fileType,
+		onChoose: wrappedOnChoose,
+		isScanning: true,
+	});
+	modal.open();
 
-    const wrappedOnChoose = (file: TFile) => {
-        recordRecentFileSelection(fileType, file.path);
-        void Promise.resolve(onChoose(file));
-    };
+	const validFiles = await collectMatchingInkSvgFiles(plugin, svgFiles, fileType);
+	if (modal.hasClosed) return;
 
-    new SvgFilePickerModal(plugin.app, {
-        title,
-        sections,
-        fileType,
-        onChoose: wrappedOnChoose,
-    }).open();
+	if (validFiles.length === 0) {
+		modal.close();
+		new Notice(`No ${fileTypeLabel} SVGs found`);
+		return;
+	}
+
+	const sections = await buildSectionedFiles(
+		plugin,
+		validFiles,
+		fileType,
+		effectiveSource ?? null,
+		noteContent
+	);
+
+	if (modal.hasClosed) return;
+	modal.setSections(sections, false);
 }


### PR DESCRIPTION
## Summary

- Opens the insert-existing handwriting/drawing modal immediately while vault SVGs are sniffed in parallel (regex file-type check instead of full DOM/JSON parse).
- Lazy-mounts inline SVG previews via IntersectionObserver and unloads off-screen DOM (keeps string cache) so scrolling many complex SVGs stays smooth.

## ClickUp

- [Inserting an existing handwriting or existing drawing is extremely slow to load the modal.](https://app.clickup.com/t/86d3p827w) - `86d3p827w`

## Test plan

- [x] `npm run build` (tsc + esbuild)
- [ ] Insert existing writing/drawing in a vault with many ink SVGs — modal should appear quickly with a scanning status, then fill
- [ ] Scroll the Other grid — previews should load near the viewport and drop DOM when scrolled away
- [ ] Confirm theme-coloured strokes still apply on visible cards

## Stack

Base: `release_0.5`
Depends on: none

Made with [Cursor](https://cursor.com)