### PR TITLE
feat: Cull off-screen strokes during SVG render

### DIFF
--- a/docs/camera-repositioning-on-resize.md
+++ b/docs/camera-repositioning-on-resize.md
@@ -165,7 +165,9 @@ y    = topMarginPx
 
 ### Dedicated writing — y-position preservation on resize
 
-When the writing dedicated view is resized, the user may have scrolled down into the document. A plain `initWritingCamera` would reset `y` back to the top margin. Instead, the resize observer callback:
+> **Current-format ink-canvas writing:** dedicated views no longer scroll via camera Y. They use a tall HTML scroller; width-fit zoom changes rescale `scrollTop` in `syncDedicatedPageCssHeight`. See [dedicated-writing-html-scroll.md](dedicated-writing-html-scroll.md).
+
+When the **legacy tldraw** writing dedicated view is resized, the user may have scrolled down into the document. A plain `initWritingCamera` would reset `y` back to the top margin. Instead, the resize observer callback:
 
 1. Captures `prevY = editor.getCamera().y`
 2. Calls `initWritingCamera` (resets zoom and x correctly, but y is now at `MENUBAR_HEIGHT_PX`)

--- a/docs/dedicated-writing-html-scroll.md
+++ b/docs/dedicated-writing-html-scroll.md
@@ -1,0 +1,85 @@
+# Dedicated writing: tall HTML page scroll
+
+## Why it exists
+
+Dedicated writing used to scroll by panning **camera Y** on every finger/wheel frame. That forced full React re-renders, outline bounds (`getStroke` × all strokes) for clamp, and expensive remounts — while markdown **embeds** already felt fine because the note’s native scroller moved a mostly fixed camera through the viewport.
+
+Dedicated writing now uses the same model: a **tall HTML page** inside an `overflow-y: auto` scroller so scroll is compositor-native and viewport culling re-evaluates without camera thrash.
+
+Drawing dedicated views still use free pan/zoom (not this architecture).
+
+---
+
+## Conceptual understanding
+
+```mermaid
+flowchart TB
+  subgraph dedicated [Dedicated writing]
+    Finger[finger_wheel] --> Scroller[ddc_ink_writing-dedicated-scroller]
+    Scroller --> Cull[viewportRevision_cull]
+    Store[stroke_commit] --> Grow[pageHeight_CSS]
+    Grow --> Scroller
+  end
+  subgraph embed [Writing embed]
+    NoteScroll[cm-scroller] --> EmbedCanvas[fixed_camera_Y0]
+  end
+```
+
+| Concern | Behavior |
+|---|---|
+| Scroll | Native scroller, not `setCamera({ y })` |
+| Camera | Pinned `x/y = 0`; zoom = `scrollerWidth / WRITING_PAGE_WIDTH` |
+| Page size | CSS height = `pageHeight × zoom`; menubar cleared with `padding-top: MENUBAR_HEIGHT_PX` |
+| Menus | Absolute overlays **outside** the scroller (do not scroll away) |
+| Pen vs finger | Pen pins the dedicated scroller (FingerBlocker); finger scrolls |
+
+---
+
+## Flows
+
+### Grow on write
+
+1. Store notify → approx content maxY → inviting height.
+2. `computeDedicatedWritingPageHeight(scrollTop, viewportHeight, zoom, inviting…)` → grow-only page height.
+3. `setWritingPageHeight` + `syncDedicatedPageCssHeight`.
+
+**Height growth must not change `scrollTop`.** Extending the page only adds space below; snapping to the bottom jumped ink under the pen. `scrollTop` is rescaled **only** when width-fit **zoom** actually changes (content portion past the fixed menubar padding).
+
+`scrollbar-gutter: stable` on the scroller reduces clientWidth shrink when a scrollbar appears mid-write (which would change zoom and shift content).
+
+### Culling + Boox
+
+`InkSvgCanvas` listens to `.ddc_ink_writing-dedicated-scroller` for `viewportRevision`. Boox overlay updates also listen to that scroller and clamp surface rects to the visible viewport.
+
+Related: [stroke viewport culling](ink-canvas-stroke-viewport-culling.md), [embed scrolling](embed-scrolling.md).
+
+---
+
+## Technical details
+
+| Piece | Location |
+|---|---|
+| Scroller / page DOM + grow sync | `writing-editor.tsx`, `writing-editor.scss` |
+| Scroll-based grow math | `computeDedicatedWritingPageHeight` in `tldraw-helpers.ts` |
+| Camera pin / no writing wheel steal | `ink-svg-canvas.tsx` |
+| Pen pin on dedicated scroller | `finger-blocker.tsx`, `restore-embed-cm-scroller-scroll.ts` |
+
+DOM shape:
+
+```
+.ddc_ink_writing-editor.ddc_ink_dedicated-editor
+  ├── .ddc_ink_writing-dedicated-scroller
+  │     └── .ddc_ink_writing-dedicated-page  (height: page×zoom; padding-top: menubar)
+  │           └── InkSvgCanvas
+  ├── .ink_primary-menu-bar   (absolute overlay)
+  └── .ink_secondary-menu-bar (absolute overlay)
+```
+
+---
+
+## Technical Gotchas
+
+1. **Do not reintroduce camera-Y pan for dedicated writing** — it regresses scroll performance on long pages.
+2. **Never snap `scrollTop` to max on grow** — that causes the mid-write jump. Leave `scrollTop` alone for height-only growth.
+3. **Legacy tldraw dedicated writing** may still use camera Y; docs under [camera-repositioning-on-resize](camera-repositioning-on-resize.md) describe that older path. Current-format ink-canvas writing uses HTML scroll.
+4. **Drawing dedicated views** keep camera pan/zoom — do not apply this tall-page layout there without a separate redesign.

--- a/docs/development.md
+++ b/docs/development.md
@@ -342,6 +342,8 @@ Troubleshooting:
 ### Related documentation
 
 - [Ink canvas: live drawing vs committed strokes](ink-canvas-live-drawing.md) — Live preview path vs stored stroke on pointer up (`InkSvgCanvas`, `draw-tool`).
+- [Ink canvas: stroke viewport culling](ink-canvas-stroke-viewport-culling.md) — Render-only skip of off-screen mounts + path `d` / approx maxY caches.
+- [Dedicated writing: tall HTML page scroll](dedicated-writing-html-scroll.md) — Native scroller instead of camera-Y pan for long writing pages.
 - [Ink canvas: capture-time point merge](ink-canvas-point-merge.md) — Hybrid append/replace-tip merge for fast smoothness and slow curves.
 - [Ink canvas: zoom-scaled stroke smoothing](ink-canvas-zoom-scaled-strokes.md) — How capture zoom scales streamline, smoothing, and duplicate-point merge at reference 1×.
 - [Pan and zoom](pan-zoom.md) — Drawing editor gestures, modifier+wheel direction (mouse vs trackpad pinch), and zoom math (`InkSvgCanvas`).

--- a/docs/ink-canvas-live-drawing.md
+++ b/docs/ink-canvas-live-drawing.md
@@ -83,6 +83,7 @@ Boox / eInk Bridge strokes may bypass parts of this path when ingested over the 
 | Live `<path>` element | `src/ink-canvas/ink-svg-canvas.tsx` (`liveStrokeRef`) |
 | Pointer handling, `points` array, live path updates | `src/ink-canvas/tools/draw-tool.ts` |
 | Committed stroke rendering | `StrokePath` in `ink-svg-canvas.tsx` — `getStroke(points, toStrokeOptions(style))`, same call the live preview makes |
+| Off-screen mounts + path cache | Viewport culling and cached path `d` — see [ink-canvas-stroke-viewport-culling.md](ink-canvas-stroke-viewport-culling.md) |
 | Current-format drawing embed | `src/components/formats/current/drawing/tldraw-drawing-editor/` |
 
 Legacy v1 drawing embeds use tldraw’s canvas directly and do not use this live-path pipeline.

--- a/docs/ink-canvas-stroke-viewport-culling.md
+++ b/docs/ink-canvas-stroke-viewport-culling.md
@@ -1,0 +1,76 @@
+# Ink canvas: stroke viewport culling and render caches
+
+## Why it exists
+
+Long writing and drawing sessions accumulate hundreds or thousands of strokes. Mounting every committed stroke as a React `StrokePath` that runs perfect-freehand `getStroke` made interaction cost scale with **document length**, not with what is on screen.
+
+Viewport culling and path caches keep interaction closer to **visible ink**, while the full stroke set stays in memory and on disk.
+
+ClickUp: [Improve performance while writing](https://app.clickup.com/t/86d3p8gt3) (`86d3p8gt3`).
+
+---
+
+## Conceptual understanding
+
+Culling and caches are **render-only**:
+
+| Layer | Culled / cached? | Role |
+|---|---|---|
+| `StrokeStore` | No cull | Source of truth for all strokes |
+| Snapshots / autosave JSON | No cull | `getSnapshot()` returns `store.getAll()` |
+| File SVG export | No cull | Rebuilds from the full stroke array via outline `getStroke` |
+| Live React SVG (`StrokePath`, writing guides) | Yes | Skip mounts off-screen; cache path `d` for mounted strokes |
+| Page-height / inviting height | Approx `maxY` | Cheap points+pad bounds — not export-quality outlines |
+
+```mermaid
+flowchart LR
+  Store[StrokeStore_all_strokes] --> Filter[page_rect_intersection]
+  Filter -->|visible_or_selected| Mount[StrokePath_cached_d]
+  Filter -->|off_screen| Skip[no_DOM_mount]
+  Store --> Snapshot[getSnapshot_and_file_export]
+  Store --> ApproxMaxY[computeApproxContentMaxY]
+  ApproxMaxY --> PageGrow[writing_page_height]
+```
+
+---
+
+## Flows
+
+### Visibility (each canvas render)
+
+1. Intersect canvas container with the browser viewport (+ ~80px margin) → page-space rect via camera.
+2. For each store stroke: keep selected; else intersect approx AABB with that rect.
+3. Mount `StrokePath` only when visible. Writing guide lines use an index range over the same Y band (not `Array.from(full page)` + nulls).
+
+Scroll listeners (`.cm-scroller`, `.ddc_ink_writing-dedicated-scroller`, window / `visualViewport`) bump `viewportRevision` so culling re-runs without mutating the store.
+
+### Path `d` cache
+
+`StrokePath` is `React.memo`’d. SVG path `d` is cached by stroke id; **offset is a CSS translate** so select-and-move does not recompute outlines. Store notifications clear the cache (points/style may have changed).
+
+### Approx content `maxY`
+
+`computeApproxContentMaxY` drives writing page-height / inviting grow so store updates do not pay `getStroke` for every stroke. Outline `computeStrokesBounds` remains for export and mode conversion.
+
+---
+
+## Technical details
+
+| Piece | Location |
+|---|---|
+| Approx AABB, content maxY, visible page rect | `src/ink-canvas/stroke-viewport-culling.ts` |
+| Cull filter, caches, guide band, scroll bump | `src/ink-canvas/ink-svg-canvas.tsx` |
+| Inviting height using approx maxY | `writing-editor.tsx` |
+
+Tradeoffs: approx bounds bias high (extra empty ruled space is fine). Scroll remounts still cost until `d` hits cache. Mid-stroke live preview is separate and unaffected.
+
+Related: [dedicated writing HTML scroll](dedicated-writing-html-scroll.md) — how dedicated views scroll without camera-Y thrash.
+
+---
+
+## Technical Gotchas
+
+1. **Do not derive saves from the live SVG DOM** — culled strokes would disappear. Use `StrokeStore` / `getSnapshot()` / export helpers.
+2. **Selected strokes always mount** — select-tool moves DOM groups.
+3. **Cache clear is wholesale on store notify** — correct after erase/replace; moves only need transform if `d` were kept (today clear is simple and safe).
+4. **Export still outlines every stroke** — intentional; not part of this optimization.

--- a/src/components/formats/current/utils/tldraw-helpers.ts
+++ b/src/components/formats/current/utils/tldraw-helpers.ts
@@ -1000,18 +1000,20 @@ export function extendWritingTemplateToFillViewport(editor: Editor, topReservedP
 
 /**
  * Pure helper for ink-canvas dedicated writing view page height.
- * Mirrors resizeWritingTemplateForDedicatedView without a tldraw Editor.
+ * Uses native scroller metrics (scrollTop + viewport) so the ruled page fills
+ * what is on screen plus a buffer — mirrors the old camera-Y formula where
+ * scrollTop ≡ -cameraY.
  *
  * @param invitingContentHeight Inviting page height from stroke content (e.g. getInvitingWritingBounds().h).
  */
 export function computeDedicatedWritingPageHeight(
-	cameraY: number,
+	scrollTopPx: number,
 	viewportHeightPx: number,
 	zoom: number,
 	invitingContentHeight: number,
 	lineHeight: number = WRITING_LINE_HEIGHT,
 ): number {
-	const pageBottomVisible = (viewportHeightPx - cameraY) / zoom;
+	const pageBottomVisible = (scrollTopPx + viewportHeightPx) / zoom;
 	const minFromViewport = pageBottomVisible + 10 * lineHeight;
 	return Math.max(minFromViewport, invitingContentHeight);
 }
@@ -1033,7 +1035,7 @@ export function resizeWritingTemplateForDedicatedView(editor: Editor): number | 
 	const contentBounds = getInvitingWritingBounds(editor);
 	const invitingContentHeight = contentBounds ? contentBounds.h : WRITING_MIN_PAGE_HEIGHT;
 	const targetHeight = computeDedicatedWritingPageHeight(
-		camera.y,
+		-camera.y,
 		viewportHeight,
 		zoom,
 		invitingContentHeight,

--- a/src/components/formats/current/writing/writing-editor/writing-editor.scss
+++ b/src/components/formats/current/writing/writing-editor/writing-editor.scss
@@ -20,6 +20,9 @@
 		overflow-x: hidden;
 		overflow-y: auto;
 		-webkit-overflow-scrolling: touch;
+		// Avoid clientWidth shrink when the scrollbar appears mid-write (that would
+		// change width-fit zoom and shift content under the pen).
+		scrollbar-gutter: stable;
 	}
 
 	.ddc_ink_writing-dedicated-page {

--- a/src/components/formats/current/writing/writing-editor/writing-editor.scss
+++ b/src/components/formats/current/writing/writing-editor/writing-editor.scss
@@ -11,6 +11,29 @@
 	}
 }
 
+// Dedicated writing: native tall-page scroll (camera Y stays pinned). Menus stay absolute
+// overlays on the editor root so chrome does not scroll with the page.
+.ddc_ink_writing-editor.ddc_ink_dedicated-editor {
+	.ddc_ink_writing-dedicated-scroller {
+		position: absolute;
+		inset: 0;
+		overflow-x: hidden;
+		overflow-y: auto;
+		-webkit-overflow-scrolling: touch;
+	}
+
+	.ddc_ink_writing-dedicated-page {
+		width: 100%;
+		position: relative;
+
+		.ink-svg-canvas-wrapper,
+		.ink-svg-canvas-container {
+			width: 100%;
+			height: 100%;
+		}
+	}
+}
+
 // .ddc_ink_writing-editor {
 //     transition: height 0.5s ease;
     

--- a/src/components/formats/current/writing/writing-editor/writing-editor.tsx
+++ b/src/components/formats/current/writing/writing-editor/writing-editor.tsx
@@ -129,6 +129,8 @@ export function WritingEditor(props: WritingEditorProps) {
 	const dedicatedScrollerRef = useRef<HTMLDivElement>(null);
 	const dedicatedPageRef = useRef<HTMLDivElement>(null);
 	const [dedicatedPageCssHeightPx, setDedicatedPageCssHeightPx] = React.useState<number | null>(null);
+	/** Last width-fit zoom applied to dedicated page CSS — used only when zoom changes. */
+	const dedicatedLastZoomRef = useRef<number | null>(null);
 
 	React.useEffect(() => {
 		if (!isFingerDrawingGloballyEnabled) setIsFingerDrawingActive(false);
@@ -306,6 +308,9 @@ export function WritingEditor(props: WritingEditorProps) {
 	/**
 	 * Map writing pageHeight (page units) → CSS px for the tall dedicated page.
 	 * zoom = scrollerWidth / WRITING_PAGE_WIDTH (same width-fit as the canvas camera).
+	 *
+	 * Height growth must not change scrollTop — that would jump ink under the pen.
+	 * Only rescale scrollTop when width-fit zoom actually changes.
 	 */
 	function syncDedicatedPageCssHeight(options?: {
 		pageHeight?: number;
@@ -322,27 +327,23 @@ export function WritingEditor(props: WritingEditorProps) {
 			?? WRITING_MIN_PAGE_HEIGHT;
 		const nextCssHeight = pageHeight * zoom;
 		const prevScrollTop = scroller.scrollTop;
-		const prevScrollHeight = scroller.scrollHeight;
-		const prevClientHeight = scroller.clientHeight;
-		const wasNearBottom = prevScrollHeight > 0
-			&& (prevScrollHeight - prevScrollTop - prevClientHeight) < prevClientHeight;
+		const prevZoom = dedicatedLastZoomRef.current;
 
 		setDedicatedPageCssHeightPx(nextCssHeight);
+		dedicatedLastZoomRef.current = zoom;
 
-		if (options?.preservePageScroll) {
+		if (
+			options?.preservePageScroll
+			&& prevZoom != null
+			&& Math.abs(prevZoom - zoom) > 1e-6
+		) {
 			window.requestAnimationFrame(() => {
 				const el = dedicatedScrollerRef.current;
 				if (!el) return;
-				if (wasNearBottom) {
-					el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
-					return;
-				}
-				// Width-fit zoom change: keep the same page-space scroll position.
-				const contentScrollRange = Math.max(prevScrollHeight - MENUBAR_HEIGHT_PX, 1);
-				const prevZoom = contentScrollRange / Math.max(pageHeight, 1);
-				if (prevZoom > 0 && Math.abs(prevZoom - zoom) > 1e-6) {
-					el.scrollTop = prevScrollTop * (zoom / prevZoom);
-				}
+				// Menubar padding is fixed CSS px; only rescale the content scroll past it.
+				const pad = MENUBAR_HEIGHT_PX;
+				const contentScrollTop = Math.max(0, prevScrollTop - pad);
+				el.scrollTop = pad + contentScrollTop * (zoom / prevZoom);
 			});
 		}
 	}

--- a/src/components/formats/current/writing/writing-editor/writing-editor.tsx
+++ b/src/components/formats/current/writing/writing-editor/writing-editor.tsx
@@ -16,8 +16,6 @@ import {
 	WRITING_MIN_PAGE_HEIGHT,
 	WRITING_PAGE_WIDTH,
 } from 'src/constants';
-import { clampWritingCameraY } from 'src/ink-canvas/camera';
-import { createPanMomentumController, isTrackpadWheel, type PanMomentumController } from 'src/ink-canvas/pan-momentum';
 import { PrimaryMenuBar } from 'src/components/jsx-components/primary-menu-bar/primary-menu-bar';
 import { InkCanvasDrawingMenu } from 'src/components/jsx-components/drawing-menu/ink-canvas-drawing-menu';
 import ExtendedWritingMenu from 'src/components/jsx-components/extended-writing-menu/extended-writing-menu';
@@ -40,7 +38,8 @@ import {
 	recordEmbedCanvasActionOnUnifiedStack,
 } from 'src/logic/undo-redo/embedded-unified-undo';
 import { InkSvgCanvas } from 'src/ink-canvas/ink-svg-canvas';
-import { renderWritingStrokesToSvg, computeStrokesBounds } from 'src/ink-canvas/svg-export';
+import { renderWritingStrokesToSvg } from 'src/ink-canvas/svg-export';
+import { computeApproxContentMaxY } from 'src/ink-canvas/stroke-viewport-culling';
 import { migrateWritingFromTldraw } from 'src/ink-canvas/migrate-from-tldraw';
 import type { PageBounds } from './page-bounds';
 import {
@@ -125,13 +124,11 @@ export function WritingEditor(props: WritingEditorProps) {
 	const curHeightRef = useRef<number | null>(null);
 	/** When true, next page-height change bypasses Boox auto-resize skip (expand-lines button). */
 	const forceNextPageHeightChangeRef = useRef(false);
-	const dedicatedWritingScrollMomentumRef = useRef<PanMomentumController | null>(null);
 	const isLegacyInkFileRef = useRef(false);
-
-	React.useEffect(() => {
-		dedicatedWritingScrollMomentumRef.current = createPanMomentumController({ axis: 'y' });
-		return () => dedicatedWritingScrollMomentumRef.current?.cancel();
-	}, []);
+	/** Dedicated writing: native tall-page scroller (not camera pan). */
+	const dedicatedScrollerRef = useRef<HTMLDivElement>(null);
+	const dedicatedPageRef = useRef<HTMLDivElement>(null);
+	const [dedicatedPageCssHeightPx, setDedicatedPageCssHeightPx] = React.useState<number | null>(null);
 
 	React.useEffect(() => {
 		if (!isFingerDrawingGloballyEnabled) setIsFingerDrawingActive(false);
@@ -243,10 +240,13 @@ export function WritingEditor(props: WritingEditorProps) {
 
 	React.useEffect(() => {
 		if (!initialSnapshot) return;
-		if (!editorWrapperRefEl.current) return;
 		if (!getBooxConnectionEnabled()) return;
+		if (!editorWrapperRefEl.current) return;
 
-		const scrollEl = editorWrapperRefEl.current.closest('.cm-scroller');
+		// Embed: Obsidian note scroller. Dedicated: tall writing page scroller.
+		const scrollEl = props.embedded
+			? editorWrapperRefEl.current.closest('.cm-scroller')
+			: dedicatedScrollerRef.current;
 		if (!scrollEl) return;
 
 		const onScroll = () => {
@@ -270,13 +270,16 @@ export function WritingEditor(props: WritingEditorProps) {
 			visualViewport?.removeEventListener('scroll', onVisualViewportChange);
 			visualViewport?.removeEventListener('resize', onVisualViewportChange);
 		};
-	}, [initialSnapshot]);
+	}, [initialSnapshot, props.embedded]);
 
 	React.useEffect(() => {
 		if (!initialSnapshot) return;
 		if (!editorWrapperRefEl.current) return;
 
 		const resizeObserver = new ResizeObserver(() => {
+			if (!props.embedded) {
+				syncDedicatedPageCssHeight({ preservePageScroll: true });
+			}
 			if (pendingNewOverlayRef.current && isViewActiveRef.current && websocketConnectedRef.current) {
 				const sent = newAndroidDrawingArea();
 				if (sent) {
@@ -293,96 +296,56 @@ export function WritingEditor(props: WritingEditorProps) {
 				sendAdjustmentImmediate();
 			}
 		});
-		resizeObserver.observe(editorWrapperRefEl.current);
+		const observeTarget = props.embedded
+			? editorWrapperRefEl.current
+			: (dedicatedScrollerRef.current ?? editorWrapperRefEl.current);
+		resizeObserver.observe(observeTarget);
 		return () => resizeObserver.disconnect();
-	}, [initialSnapshot]);
-
-	function getScrollContentBottomPageY(editor: InkCanvasEditor): number {
-		const strokes = editor.getSnapshot().strokes;
-		if (strokes.length === 0) return WRITING_MIN_PAGE_HEIGHT;
-		return Math.max(computeStrokesBounds(strokes).maxY, WRITING_MIN_PAGE_HEIGHT);
-	}
-
-	function clampDedicatedWritingCamera(editor: InkCanvasEditor, cameraY: number): number {
-		const container = editor.getContainerElement();
-		const viewportHeightPx = container?.clientHeight ?? 0;
-		const zoom = editor.getCamera().zoom;
-		return clampWritingCameraY(
-			cameraY,
-			zoom,
-			viewportHeightPx,
-			getScrollContentBottomPageY(editor),
-			MENUBAR_HEIGHT_PX,
-		);
-	}
-
-	function applyDedicatedInkWritingVerticalScrollImmediate(deltaScreenPx: number): boolean {
-		const editor = editorRef.current;
-		if (!editor) return false;
-		const camera = editor.getCamera();
-		const newY = camera.y - deltaScreenPx / camera.zoom;
-		const clampedY = clampDedicatedWritingCamera(editor, newY);
-		const hitClamp = Math.abs(clampedY - camera.y) < 1e-9 && Math.abs(newY - clampedY) > 1e-9;
-		editor.setCamera({
-			x: camera.x,
-			y: clampedY,
-			zoom: camera.zoom,
-		});
-		return !hitClamp;
-	}
-
-	function releaseDedicatedWritingScrollMomentum() {
-		dedicatedWritingScrollMomentumRef.current?.release((_deltaScreenX, deltaScreenY) =>
-			applyDedicatedInkWritingVerticalScrollImmediate(deltaScreenY),
-		);
-	}
-
-	function applyDedicatedInkWritingVerticalScroll(deltaScreenPx: number) {
-		dedicatedWritingScrollMomentumRef.current?.recordScreenDelta(0, deltaScreenPx);
-		applyDedicatedInkWritingVerticalScrollImmediate(deltaScreenPx);
-	}
-
-	// Dedicated view: capture-phase wheel so Obsidian does not steal vertical scroll
-	React.useEffect(() => {
-		if (!initialSnapshot) return;
-		if (props.embedded) return;
-		const wrapperEl = editorWrapperRefEl.current;
-		if (!wrapperEl) return;
-
-		const TRACKPAD_WHEEL_IDLE_MS = 80;
-		let wheelIdleTimer: number | null = null;
-
-		const clearTrackpadWheelIdleTimer = () => {
-			if (wheelIdleTimer !== null) {
-				window.clearTimeout(wheelIdleTimer);
-				wheelIdleTimer = null;
-			}
-		};
-
-		const onWheelScroll = (e: WheelEvent) => {
-			e.preventDefault();
-			e.stopPropagation();
-			let deltaY = e.deltaY;
-			if (e.deltaMode === WheelEvent.DOM_DELTA_LINE) deltaY *= 16;
-			if (e.deltaMode === WheelEvent.DOM_DELTA_PAGE) deltaY *= 600;
-			if (isTrackpadWheel(e)) {
-				clearTrackpadWheelIdleTimer();
-				wheelIdleTimer = window.setTimeout(() => {
-					wheelIdleTimer = null;
-					releaseDedicatedWritingScrollMomentum();
-				}, TRACKPAD_WHEEL_IDLE_MS);
-			} else {
-				clearTrackpadWheelIdleTimer();
-				dedicatedWritingScrollMomentumRef.current?.cancel();
-			}
-			applyDedicatedInkWritingVerticalScroll(deltaY);
-		};
-		wrapperEl.addEventListener('wheel', onWheelScroll, { capture: true, passive: false });
-		return () => {
-			clearTrackpadWheelIdleTimer();
-			wrapperEl.removeEventListener('wheel', onWheelScroll, { capture: true });
-		};
 	}, [initialSnapshot, props.embedded]);
+
+	/**
+	 * Map writing pageHeight (page units) → CSS px for the tall dedicated page.
+	 * zoom = scrollerWidth / WRITING_PAGE_WIDTH (same width-fit as the canvas camera).
+	 */
+	function syncDedicatedPageCssHeight(options?: {
+		pageHeight?: number;
+		preservePageScroll?: boolean;
+	}) {
+		if (props.embedded) return;
+		const scroller = dedicatedScrollerRef.current;
+		const editor = editorRef.current;
+		if (!scroller) return;
+
+		const zoom = Math.max(scroller.clientWidth, 1) / WRITING_PAGE_WIDTH;
+		const pageHeight = options?.pageHeight
+			?? editor?.getPageHeight()
+			?? WRITING_MIN_PAGE_HEIGHT;
+		const nextCssHeight = pageHeight * zoom;
+		const prevScrollTop = scroller.scrollTop;
+		const prevScrollHeight = scroller.scrollHeight;
+		const prevClientHeight = scroller.clientHeight;
+		const wasNearBottom = prevScrollHeight > 0
+			&& (prevScrollHeight - prevScrollTop - prevClientHeight) < prevClientHeight;
+
+		setDedicatedPageCssHeightPx(nextCssHeight);
+
+		if (options?.preservePageScroll) {
+			window.requestAnimationFrame(() => {
+				const el = dedicatedScrollerRef.current;
+				if (!el) return;
+				if (wasNearBottom) {
+					el.scrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+					return;
+				}
+				// Width-fit zoom change: keep the same page-space scroll position.
+				const contentScrollRange = Math.max(prevScrollHeight - MENUBAR_HEIGHT_PX, 1);
+				const prevZoom = contentScrollRange / Math.max(pageHeight, 1);
+				if (prevZoom > 0 && Math.abs(prevZoom - zoom) > 1e-6) {
+					el.scrollTop = prevScrollTop * (zoom / prevZoom);
+				}
+			});
+		}
+	}
 
 	function handleEditorReady(editor: InkCanvasEditor) {
 		editorRef.current = editor;
@@ -454,7 +417,7 @@ export function WritingEditor(props: WritingEditorProps) {
 		const bufferLines = props.plugin.settings.writingBufferLines;
 		const strokes = editor.getSnapshot().strokes;
 		const contentHeight = strokes.length > 0
-			? computeStrokesBounds(strokes).maxY
+			? computeApproxContentMaxY(strokes)
 			: 0;
 		return cropWritingStrokeHeightInvitingly(contentHeight, bufferLines, lineHeight);
 	}
@@ -574,25 +537,31 @@ export function WritingEditor(props: WritingEditorProps) {
 			return;
 		}
 
-		// Dedicated view: grow page to cover viewport bottom + content (never shrink)
-		const container = editor.getContainerElement();
-		const viewportHeightPx = container?.clientHeight ?? 0;
-		const camera = editor.getCamera();
+		// Dedicated view: grow tall HTML page for viewport bottom + content (never shrink).
+		// scrollTop is offset by MENUBAR padding above the canvas content.
+		const scroller = dedicatedScrollerRef.current;
+		const viewportHeightPx = scroller?.clientHeight ?? 0;
+		const scrollTopPx = Math.max(0, (scroller?.scrollTop ?? 0) - MENUBAR_HEIGHT_PX);
+		const zoom = Math.max(scroller?.clientWidth ?? 1, 1) / WRITING_PAGE_WIDTH;
 		const targetHeight = computeDedicatedWritingPageHeight(
-			camera.y,
+			scrollTopPx,
 			viewportHeightPx,
-			camera.zoom,
+			zoom,
 			invitingFromContent,
 			lineHeight,
 		);
 		if (targetHeight > editor.getPageHeight()) {
 			editor.setWritingPageHeight(targetHeight);
 			curHeightRef.current = targetHeight;
-			const cam = editor.getCamera();
-			editor.setCamera({
-				x: cam.x,
-				y: clampDedicatedWritingCamera(editor, cam.y),
-				zoom: cam.zoom,
+			syncDedicatedPageCssHeight({
+				pageHeight: targetHeight,
+				preservePageScroll: true,
+			});
+		} else if (isInitialMount || dedicatedPageCssHeightPx === null) {
+			curHeightRef.current = editor.getPageHeight();
+			syncDedicatedPageCssHeight({
+				pageHeight: editor.getPageHeight(),
+				preservePageScroll: false,
 			});
 		}
 	}
@@ -604,7 +573,7 @@ export function WritingEditor(props: WritingEditorProps) {
 		const strokes = editorRef.current?.getSnapshot().strokes ?? [];
 		const lineHeight = writingLineHeightRef.current;
 		const tightHeight = strokes.length > 0
-			? cropWritingStrokeHeightTightly(computeStrokesBounds(strokes).maxY, lineHeight)
+			? cropWritingStrokeHeightTightly(computeApproxContentMaxY(strokes), lineHeight)
 			: WRITING_MIN_PAGE_HEIGHT;
 		const tightBounds: PageBounds = { x: 0, y: 0, w: pw, h: tightHeight };
 		if (getBooxConnectionEnabled() && websocketConnectedRef.current) {
@@ -950,6 +919,29 @@ export function WritingEditor(props: WritingEditorProps) {
 
 	if (!initialSnapshot) return <></>;
 
+	const canvas = (
+		<InkSvgCanvas
+			initialSnapshot={initialSnapshot}
+			writingMode={true}
+			pageWidth={WRITING_PAGE_WIDTH}
+			writingBufferLines={props.plugin.settings.writingBufferLines}
+			onEditorReady={handleEditorReady}
+			onChange={handleStoreChange}
+			onEmbedUndoStackPush={handleEmbedUndoStackPush}
+			onPageHeightChange={handlePageHeightChange}
+			isEmbedded={props.embedded}
+			isBooxInputLocked={isBooxInputLocked}
+			isFingerDrawingActive={isFingerDrawingActive}
+			// Writing always pins its scroll parent on pen (note scroller or dedicated scroller).
+			blockObsidianPenGestures={true}
+			onBooxEmbedGeometryChange={
+				isBooxInputLocked
+					? repositionBooxOverlayAfterEmbedGeometryChange
+					: undefined
+			}
+		/>
+	);
+
 	return <>
 		<div
 			ref={editorWrapperRefEl}
@@ -979,31 +971,25 @@ export function WritingEditor(props: WritingEditorProps) {
 				}
 			}}
 		>
-			<InkSvgCanvas
-				initialSnapshot={initialSnapshot}
-				writingMode={true}
-				pageWidth={WRITING_PAGE_WIDTH}
-				writingBufferLines={props.plugin.settings.writingBufferLines}
-				onEditorReady={handleEditorReady}
-				onChange={handleStoreChange}
-				onEmbedUndoStackPush={handleEmbedUndoStackPush}
-				onPageHeightChange={handlePageHeightChange}
-				onDedicatedVerticalTouchPan={
-					props.embedded ? undefined : applyDedicatedInkWritingVerticalScroll
-				}
-				onPanGestureEnd={
-					props.embedded ? undefined : releaseDedicatedWritingScrollMomentum
-				}
-				isEmbedded={props.embedded}
-				isBooxInputLocked={isBooxInputLocked}
-				isFingerDrawingActive={isFingerDrawingActive}
-				blockObsidianPenGestures={props.embedded || isBooxInputLocked}
-				onBooxEmbedGeometryChange={
-					props.embedded && isBooxInputLocked
-						? repositionBooxOverlayAfterEmbedGeometryChange
-						: undefined
-				}
-			/>
+			{props.embedded ? canvas : (
+				<div
+					ref={dedicatedScrollerRef}
+					className="ddc_ink_writing-dedicated-scroller"
+				>
+					{/* padding-top clears the fixed primary menu (replaces old camera Y offset). */}
+					<div
+						ref={dedicatedPageRef}
+						className="ddc_ink_writing-dedicated-page"
+						style={{
+							height: dedicatedPageCssHeightPx ?? '100%',
+							paddingTop: MENUBAR_HEIGHT_PX,
+							boxSizing: 'content-box',
+						}}
+					>
+						{canvas}
+					</div>
+				</div>
+			)}
 
 			<PrimaryMenuBar>
 				<InkCanvasDrawingMenu

--- a/src/components/jsx-components/finger-blocker/finger-blocker.tsx
+++ b/src/components/jsx-components/finger-blocker/finger-blocker.tsx
@@ -238,7 +238,10 @@ export function FingerBlocker({
 
 	const getScroller = (): HTMLElement | null => {
 		const wrapper = getWrapper();
-		return wrapper ? (wrapper.closest('.cm-scroller')) : null;
+		if (!wrapper) return null;
+		// Embeds ride Obsidian's note scroller; dedicated writing uses its own tall-page scroller.
+		return wrapper.closest('.cm-scroller')
+			?? wrapper.closest('.ddc_ink_writing-dedicated-scroller');
 	};
 
 	const lockScroll = () => {

--- a/src/ink-canvas/ink-svg-canvas.tsx
+++ b/src/ink-canvas/ink-svg-canvas.tsx
@@ -1,20 +1,21 @@
 import './ink-svg-canvas.scss';
-import React, { useEffect, useLayoutEffect, useRef, useCallback, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useCallback, useState, memo } from 'react';
 import { getStroke } from 'perfect-freehand';
 import { getSvgPathFromStroke } from './utils/svg-path-from-stroke';
 import { StrokeStore } from './stroke-store';
 import { UndoManager } from './undo-manager';
-import { panByScreenDelta, zoomAtPoint, clampZoom, clampWritingCameraY, fitBoundsToViewport, adjustCameraToPreservePagePointAtScreenTargets, adjustCameraToPreserveViewportCenter, screenToPage as screenToPageFn, getRightDragZoomDelta } from './camera';
+import { panByScreenDelta, zoomAtPoint, clampZoom, fitBoundsToViewport, adjustCameraToPreservePagePointAtScreenTargets, adjustCameraToPreserveViewportCenter, screenToPage as screenToPageFn, getRightDragZoomDelta } from './camera';
 import { createPanMomentumController, createModifierWheelZoomDirectionResolver, isTrackpadWheel, type PanMomentumController } from './pan-momentum';
 import { computeStrokesBounds } from './svg-export';
 import {
+	computeApproxContentMaxY,
 	computeApproxStrokePageBounds,
 	pageRectsIntersect,
 	visiblePageRectFromContainer,
 	type PageRect,
 } from './stroke-viewport-culling';
 import { cropWritingStrokeHeightInvitingly } from 'src/components/formats/current/utils/tldraw-helpers';
-import { MENUBAR_HEIGHT_PX, WRITING_LINE_HEIGHT, WRITING_MIN_PAGE_HEIGHT, WRITING_PAGE_WIDTH } from 'src/constants';
+import { WRITING_LINE_HEIGHT, WRITING_PAGE_WIDTH } from 'src/constants';
 import { AddStrokeCommand, EraseAllCommand, RemoveStrokesCommand } from './commands';
 import { drawToolPointerDown, drawToolPointerMove, drawToolPointerUp, drawToolPointerCancel } from './tools/draw-tool';
 import { eraseToolPointerDown, eraseToolPointerMove, eraseToolPointerUp, eraseToolPointerCancel } from './tools/erase-tool';
@@ -82,8 +83,6 @@ export interface InkSvgCanvasProps {
 	writingBufferLines?: number;
 	/** Called when inviting page height should be recomputed (writing mode only). */
 	onPageHeightChange?: (candidateHeightPx: number) => void;
-	/** Dedicated writing view: vertical touch pan callback (screen pixels). */
-	onDedicatedVerticalTouchPan?: (deltaY: number) => void;
 	/** Fired when a pan/scroll gesture ends (start flick momentum in parent if needed). */
 	onPanGestureEnd?: () => void;
 	/** When true, ignore local draw/erase/select pointer input (Boox WebSocket creates strokes). */
@@ -121,8 +120,9 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 
 	function computeInitialPageHeight(): number {
 		const strokes = props.initialSnapshot?.strokes ?? [];
+		// Approx maxY — same helper as store updates; export still uses outline bounds.
 		const contentHeight = strokes.length > 0
-			? computeStrokesBounds(strokes).maxY
+			? computeApproxContentMaxY(strokes)
 			: 0;
 		return cropWritingStrokeHeightInvitingly(contentHeight, writingBufferLines, writingLineHeight);
 	}
@@ -153,6 +153,8 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 	// Bumped on note/window scroll so render-time culling re-evaluates without touching StrokeStore.
 	const [viewportRevision, setViewportRevision] = useState(0);
 	const strokeBoundsCacheRef = useRef(new Map<string, PageRect>());
+	// Cached SVG path `d` per stroke id — offset is applied via transform, so moves do not bust this.
+	const strokePathDCacheRef = useRef(new Map<string, string>());
 
 	// Refs that stay in sync with state so tool callbacks see current values
 	const cameraRef = useRef(camera);
@@ -198,57 +200,24 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 	strokeStyleRef.current = strokeStyle;
 	const selectedIdsRef = useRef(selectedIds);
 	selectedIdsRef.current = selectedIds;
-	const onDedicatedVerticalTouchPanRef = useRef(props.onDedicatedVerticalTouchPan);
-	onDedicatedVerticalTouchPanRef.current = props.onDedicatedVerticalTouchPan;
 
 	const panMomentumRef = useRef<PanMomentumController | null>(null);
 	useEffect(() => {
+		// Dedicated writing scrolls via HTML; drawing (and any residual writing pan) use xy.
 		panMomentumRef.current = createPanMomentumController({
-			axis: writingMode && !props.isEmbedded ? 'y' : 'xy',
+			axis: 'xy',
 		});
 		return () => panMomentumRef.current?.cancel();
-	}, [writingMode, props.isEmbedded]);
-
-	const getScrollContentBottomPageY = useCallback((): number => {
-		const strokes = storeRef.current.getAll();
-		if (strokes.length === 0) return WRITING_MIN_PAGE_HEIGHT;
-		return Math.max(computeStrokesBounds(strokes).maxY, WRITING_MIN_PAGE_HEIGHT);
 	}, []);
 
-	const clampWritingY = useCallback((y: number, zoom: number): number => {
-		const container = containerRef.current;
-		if (!container) return y;
-		const cameraYMax = props.isEmbedded ? 0 : MENUBAR_HEIGHT_PX;
-		return clampWritingCameraY(
-			y,
-			zoom,
-			container.clientHeight,
-			getScrollContentBottomPageY(),
-			cameraYMax,
-		);
-	}, [getScrollContentBottomPageY, props.isEmbedded]);
-
 	const applyPanScreenDeltaImmediate = useCallback((deltaScreenX: number, deltaScreenY: number): boolean => {
+		// Dedicated writing: vertical motion is native scroller — do not pan the camera.
 		if (writingMode && !props.isEmbedded) {
-			let hitClamp = false;
-			let nextCamera: CameraState | null = null;
-			setCameraState((prev) => {
-				const newY = clampWritingY(prev.y + deltaScreenY / prev.zoom, prev.zoom);
-				if (Math.abs(newY - prev.y) < 1e-9 && Math.abs(deltaScreenY) > 1e-9) {
-					hitClamp = true;
-				}
-				nextCamera = { ...prev, y: newY };
-				cameraRef.current = nextCamera;
-				return nextCamera;
-			});
-			if (nextCamera) {
-				emitCameraChange(nextCamera, { source: 'user' });
-			}
-			return !hitClamp;
+			return false;
 		}
 		commitUserCameraState((prev) => panByScreenDelta(prev, deltaScreenX, deltaScreenY));
 		return true;
-	}, [writingMode, props.isEmbedded, clampWritingY, commitUserCameraState, emitCameraChange]);
+	}, [writingMode, props.isEmbedded, commitUserCameraState]);
 
 	const applyPanScreenDelta = useCallback((deltaScreenX: number, deltaScreenY: number) => {
 		panMomentumRef.current?.recordScreenDelta(deltaScreenX, deltaScreenY);
@@ -269,16 +238,11 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 		const container = containerRef.current;
 		if (!container) return;
 		const zoom = container.clientWidth / pageWidth;
-		let prevY: number;
-		if (preserveY) {
-			prevY = cameraRef.current.y;
-		} else if (props.isEmbedded) {
-			prevY = 0;
-		} else {
-			prevY = MENUBAR_HEIGHT_PX;
-		}
+		// Dedicated writing uses HTML page scroll + padding for the menubar; keep camera Y at 0
+		// (embeds already used Y = 0). preserveY is only for width-refit mid-session.
+		const prevY = preserveY ? cameraRef.current.y : 0;
 		setCameraState({ x: 0, y: prevY, zoom });
-	}, [pageWidth, props.isEmbedded]);
+	}, [pageWidth]);
 
 	// Camera is never persisted — fit on mount. Use layout effect so initial camera applies before paint.
 	useLayoutEffect(() => {
@@ -343,8 +307,9 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 	// Subscribe to store changes to re-render strokes
 	useEffect(() => {
 		const unsubStore = storeRef.current.subscribe(() => {
-			// Invalidate cull bounds — offsets/points may have changed; store still holds every stroke.
+			// Invalidate cull bounds + path `d` — points/style may have changed; store still holds every stroke.
 			strokeBoundsCacheRef.current.clear();
+			strokePathDCacheRef.current.clear();
 			forceRender(n => n + 1);
 			props.onChange?.();
 
@@ -352,7 +317,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 				const allStrokes = storeRef.current.getAll();
 				const lh = props.initialSnapshot?.writingLineHeight ?? WRITING_LINE_HEIGHT;
 				const contentHeight = allStrokes.length > 0
-					? computeStrokesBounds(allStrokes).maxY
+					? computeApproxContentMaxY(allStrokes)
 					: 0;
 				const candidateHeight = cropWritingStrokeHeightInvitingly(
 					contentHeight,
@@ -386,7 +351,10 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 		};
 
 		const noteScroller = container.closest('.cm-scroller');
+		// Dedicated writing: tall HTML scroller (not camera pan) — re-cull as the page scrolls.
+		const dedicatedScroller = container.closest('.ddc_ink_writing-dedicated-scroller');
 		noteScroller?.addEventListener('scroll', bumpViewportRevision, { passive: true });
+		dedicatedScroller?.addEventListener('scroll', bumpViewportRevision, { passive: true });
 		window.addEventListener('scroll', bumpViewportRevision, { passive: true, capture: true });
 		window.addEventListener('resize', bumpViewportRevision);
 		const visualViewport = window.visualViewport;
@@ -396,6 +364,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 		return () => {
 			if (rafId) window.cancelAnimationFrame(rafId);
 			noteScroller?.removeEventListener('scroll', bumpViewportRevision);
+			dedicatedScroller?.removeEventListener('scroll', bumpViewportRevision);
 			window.removeEventListener('scroll', bumpViewportRevision, true);
 			window.removeEventListener('resize', bumpViewportRevision);
 			visualViewport?.removeEventListener('scroll', bumpViewportRevision);
@@ -1019,44 +988,8 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 		};
 
 		const handleWheelNative = (e: WheelEvent) => {
-			// Embedded writing: pass wheel through to the markdown note scroller
-			if (writingMode && props.isEmbedded) {
-				return;
-			}
-			if (writingMode && !props.isEmbedded) {
-				if (e.ctrlKey || e.metaKey) return;
-				e.preventDefault();
-				const delta = e.deltaY * (e.deltaMode === WheelEvent.DOM_DELTA_LINE ? 16 : 1);
-				const usesExternalWritingPan = !!onDedicatedVerticalTouchPanRef.current;
-				if (usesExternalWritingPan) {
-					if (isTrackpadWheel(e)) {
-						scheduleTrackpadWheelRelease();
-					} else {
-						clearTrackpadWheelIdleTimer();
-						cancelPanMomentumRef.current();
-					}
-					onDedicatedVerticalTouchPanRef.current?.(delta);
-					return;
-				}
-				if (isTrackpadWheel(e)) {
-					applyPanScreenDeltaRef.current(0, -delta);
-					scheduleTrackpadWheelRelease();
-				} else {
-					clearTrackpadWheelIdleTimer();
-					cancelPanMomentumRef.current();
-					let nextCamera: CameraState | null = null;
-					setCameraState((prev) => {
-						nextCamera = {
-							...prev,
-							y: clampWritingY(prev.y - delta / prev.zoom, prev.zoom),
-						};
-						cameraRef.current = nextCamera;
-						return nextCamera;
-					});
-					if (nextCamera) {
-						emitCameraChange(nextCamera, { source: 'user' });
-					}
-				}
+			// Writing (embed note scroll or dedicated tall-page scroller): do not steal wheel.
+			if (writingMode) {
 				return;
 			}
 
@@ -1096,7 +1029,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 			modifierWheelZoomDirectionResolverRef.current.cancel();
 			svg.removeEventListener('wheel', handleWheelNative);
 		};
-	}, [writingMode, props.isEmbedded, clampWritingY, emitCameraChange]);
+	}, [writingMode, props.isEmbedded]);
 
 
 	// Space+drag pan (Phase C)
@@ -1106,7 +1039,14 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
-			const shouldActivate = e.key === ' ' && !e.repeat && !e.metaKey && !e.ctrlKey && isPointerOverCanvasRef.current && !props.isEmbedded;
+			// Writing dedicated uses HTML scroll; embeds pass Space through to the note.
+			const shouldActivate = e.key === ' '
+				&& !e.repeat
+				&& !e.metaKey
+				&& !e.ctrlKey
+				&& isPointerOverCanvasRef.current
+				&& !props.isEmbedded
+				&& !writingMode;
 			if (!shouldActivate) return;
 			isSpaceHeldRef.current = true;
 			setCursorStyle('grab');
@@ -1195,10 +1135,12 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 		return pageRectsIntersect(getCachedApproxStrokeBounds(stroke), visiblePageRect);
 	};
 
+	// Writing embeds + dedicated writing both use document scroll (cm-scroller or
+	// .ddc_ink_writing-dedicated-scroller) — never camera-Y touch pan.
 	const inkTouchGestureMode = resolveInkTouchGestureMode({
 		writingMode,
 		isEmbedded: !!props.isEmbedded,
-		hasDedicatedVerticalTouchPan: writingMode && !props.isEmbedded && !!props.onDedicatedVerticalTouchPan,
+		hasDedicatedVerticalTouchPan: false,
 	});
 
 	// FingerBlocker must sit outside overflow:hidden so iOS can chain finger scroll to .cm-scroller
@@ -1216,11 +1158,6 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 			<FingerBlocker
 				wrapperRef={canvasWrapperRef}
 				touchGestureMode={inkTouchGestureMode}
-				onVerticalTouchPan={
-					writingMode && !props.isEmbedded
-						? props.onDedicatedVerticalTouchPan
-						: undefined
-				}
 				forwardPenToCanvas={!props.isBooxInputLocked}
 				forwardFingerToCanvas={
 					!!props.isFingerDrawingActive && !props.isBooxInputLocked
@@ -1279,17 +1216,20 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 						const margin = pw * 0.05;
 						const lineCount = Math.floor(pageHeightState / lh);
 						const guideLineStrokeWidth = (isBooxConnectionEnabled ? 2 : 1) / camera.zoom;
-						return Array.from({ length: lineCount }, (_, i) => {
-							const lineY = (i + 1) * lh;
-							// Cull guide lines the same way as strokes — render-only, page height unchanged.
-							if (visiblePageRect === null) return null;
-							if (
-								visiblePageRect !== undefined
-								&& (lineY < visiblePageRect.minY || lineY > visiblePageRect.maxY)
-							) {
-								return null;
-							}
-							return (
+						// Only emit guide indices overlapping the visible page rect — avoid
+						// Array.from(full page) + null cull on tall documents during scroll.
+						if (visiblePageRect === null) return null;
+						let startIndex = 1;
+						let endIndex = lineCount;
+						if (visiblePageRect !== undefined) {
+							startIndex = Math.max(1, Math.floor(visiblePageRect.minY / lh));
+							endIndex = Math.min(lineCount, Math.ceil(visiblePageRect.maxY / lh));
+						}
+						if (endIndex < startIndex) return null;
+						const lines: React.JSX.Element[] = [];
+						for (let i = startIndex; i <= endIndex; i++) {
+							const lineY = i * lh;
+							lines.push(
 								<line
 									key={i}
 									className="ink-writing-guide-line"
@@ -1300,9 +1240,10 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 									stroke={isBooxConnectionEnabled ? 'var(--text-normal)' : 'currentColor'}
 									strokeOpacity={isBooxConnectionEnabled ? 1 : 0.5}
 									strokeWidth={guideLineStrokeWidth}
-								/>
+								/>,
 							);
-						});
+						}
+						return lines;
 					})()}
 					{/* Committed strokes — store keeps all; only visible (or selected) mount as SVG */}
 					{strokes.map(stroke => (
@@ -1311,6 +1252,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 								key={stroke.id}
 								stroke={stroke}
 								isSelected={selectedIds.has(stroke.id)}
+								pathDCache={strokePathDCacheRef.current}
 							/>
 						) : null
 					))}
@@ -1335,14 +1277,36 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 interface StrokePathProps {
 	stroke: InkStroke;
 	isSelected: boolean;
+	/** Shared cache: path `d` depends on points/style only; offset is a transform. */
+	pathDCache: Map<string, string>;
 }
 
-function StrokePath(props: StrokePathProps): React.JSX.Element {
-	const { stroke, isSelected } = props;
+function strokePathPropsAreEqual(prev: StrokePathProps, next: StrokePathProps): boolean {
+	if (prev.isSelected !== next.isSelected) return false;
+	if (prev.pathDCache !== next.pathDCache) return false;
+	const a = prev.stroke;
+	const b = next.stroke;
+	if (a === b) return true;
+	if (a.id !== b.id) return false;
+	if (a.points !== b.points) return false;
+	if (a.style !== b.style) return false;
+	// Offset-only changes still need a re-render for the translate transform, but not a new `d`.
+	if (a.offset.x !== b.offset.x || a.offset.y !== b.offset.y) return false;
+	return true;
+}
+
+const StrokePath = memo(function StrokePath(props: StrokePathProps): React.JSX.Element {
+	const { stroke, isSelected, pathDCache } = props;
 	// All strokes render through perfect-freehand's `getStroke` directly — the same call the
 	// live preview makes (see `draw-tool.ts`), so committed strokes match what was drawn.
-	const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
-	const d = getSvgPathFromStroke(outlinePoints);
+	// Cached by stroke id: parent re-renders (viewportRevision, unrelated store updates after
+	// cache clear + remount) reuse `d` when the id is still populated; offset is transform-only.
+	let d = pathDCache.get(stroke.id);
+	if (d === undefined) {
+		const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
+		d = getSvgPathFromStroke(outlinePoints);
+		pathDCache.set(stroke.id, d);
+	}
 
 	const hasOffset = stroke.offset.x !== 0 || stroke.offset.y !== 0;
 
@@ -1370,4 +1334,4 @@ function StrokePath(props: StrokePathProps): React.JSX.Element {
 			)}
 		</g>
 	);
-}
+}, strokePathPropsAreEqual);

--- a/src/ink-canvas/ink-svg-canvas.tsx
+++ b/src/ink-canvas/ink-svg-canvas.tsx
@@ -7,6 +7,12 @@ import { UndoManager } from './undo-manager';
 import { panByScreenDelta, zoomAtPoint, clampZoom, clampWritingCameraY, fitBoundsToViewport, adjustCameraToPreservePagePointAtScreenTargets, adjustCameraToPreserveViewportCenter, screenToPage as screenToPageFn, getRightDragZoomDelta } from './camera';
 import { createPanMomentumController, createModifierWheelZoomDirectionResolver, isTrackpadWheel, type PanMomentumController } from './pan-momentum';
 import { computeStrokesBounds } from './svg-export';
+import {
+	computeApproxStrokePageBounds,
+	pageRectsIntersect,
+	visiblePageRectFromContainer,
+	type PageRect,
+} from './stroke-viewport-culling';
 import { cropWritingStrokeHeightInvitingly } from 'src/components/formats/current/utils/tldraw-helpers';
 import { MENUBAR_HEIGHT_PX, WRITING_LINE_HEIGHT, WRITING_MIN_PAGE_HEIGHT, WRITING_PAGE_WIDTH } from 'src/constants';
 import { AddStrokeCommand, EraseAllCommand, RemoveStrokesCommand } from './commands';
@@ -144,6 +150,9 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 	);
 	const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 	const [, forceRender] = useState(0);
+	// Bumped on note/window scroll so render-time culling re-evaluates without touching StrokeStore.
+	const [viewportRevision, setViewportRevision] = useState(0);
+	const strokeBoundsCacheRef = useRef(new Map<string, PageRect>());
 
 	// Refs that stay in sync with state so tool callbacks see current values
 	const cameraRef = useRef(camera);
@@ -334,6 +343,8 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 	// Subscribe to store changes to re-render strokes
 	useEffect(() => {
 		const unsubStore = storeRef.current.subscribe(() => {
+			// Invalidate cull bounds — offsets/points may have changed; store still holds every stroke.
+			strokeBoundsCacheRef.current.clear();
 			forceRender(n => n + 1);
 			props.onChange?.();
 
@@ -359,6 +370,38 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 		});
 		return () => { unsubStore(); unsubUndo(); };
 	}, []); // eslint-disable-line -- stable effect deps
+
+	// Re-cull when the note scroller or window moves the canvas on/off screen (embeds + dedicated).
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container) return;
+
+		let rafId = 0;
+		const bumpViewportRevision = () => {
+			if (rafId) return;
+			rafId = window.requestAnimationFrame(() => {
+				rafId = 0;
+				setViewportRevision((n) => n + 1);
+			});
+		};
+
+		const noteScroller = container.closest('.cm-scroller');
+		noteScroller?.addEventListener('scroll', bumpViewportRevision, { passive: true });
+		window.addEventListener('scroll', bumpViewportRevision, { passive: true, capture: true });
+		window.addEventListener('resize', bumpViewportRevision);
+		const visualViewport = window.visualViewport;
+		visualViewport?.addEventListener('scroll', bumpViewportRevision);
+		visualViewport?.addEventListener('resize', bumpViewportRevision);
+
+		return () => {
+			if (rafId) window.cancelAnimationFrame(rafId);
+			noteScroller?.removeEventListener('scroll', bumpViewportRevision);
+			window.removeEventListener('scroll', bumpViewportRevision, true);
+			window.removeEventListener('resize', bumpViewportRevision);
+			visualViewport?.removeEventListener('scroll', bumpViewportRevision);
+			visualViewport?.removeEventListener('resize', bumpViewportRevision);
+		};
+	}, [props.isEmbedded, writingMode]);
 
 	// Writing mode: re-fit zoom when container width changes (not height — embed resize animates height)
 	useEffect(() => {
@@ -1126,6 +1169,32 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 
 	const cameraTransform = `scale(${camera.zoom}) translate(${camera.x}, ${camera.y})`;
 
+	// Render-only visibility: skip mounting StrokePath for fully off-screen strokes.
+	// void viewportRevision — dependency so scroll bumps re-evaluate without store changes.
+	void viewportRevision;
+	const containerRect = containerRef.current?.getBoundingClientRect() ?? null;
+	const visiblePageRect = containerRect
+		? visiblePageRectFromContainer(camera, containerRect)
+		: undefined;
+
+	const getCachedApproxStrokeBounds = (stroke: InkStroke): PageRect => {
+		const cached = strokeBoundsCacheRef.current.get(stroke.id);
+		if (cached) return cached;
+		const bounds = computeApproxStrokePageBounds(stroke);
+		strokeBoundsCacheRef.current.set(stroke.id, bounds);
+		return bounds;
+	};
+
+	const isStrokeVisibleInViewport = (stroke: InkStroke): boolean => {
+		// Always keep selected strokes mounted — select-tool moves their DOM groups.
+		if (selectedIds.has(stroke.id)) return true;
+		// Before layout, show everything to avoid a blank first paint.
+		if (visiblePageRect === undefined) return true;
+		// Fully off-screen container → cull all non-selected strokes.
+		if (visiblePageRect === null) return false;
+		return pageRectsIntersect(getCachedApproxStrokeBounds(stroke), visiblePageRect);
+	};
+
 	const inkTouchGestureMode = resolveInkTouchGestureMode({
 		writingMode,
 		isEmbedded: !!props.isEmbedded,
@@ -1210,27 +1279,40 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 						const margin = pw * 0.05;
 						const lineCount = Math.floor(pageHeightState / lh);
 						const guideLineStrokeWidth = (isBooxConnectionEnabled ? 2 : 1) / camera.zoom;
-						return Array.from({ length: lineCount }, (_, i) => (
-							<line
-								key={i}
-								className="ink-writing-guide-line"
-								x1={margin}
-								y1={(i + 1) * lh}
-								x2={pw - margin}
-								y2={(i + 1) * lh}
-								stroke={isBooxConnectionEnabled ? 'var(--text-normal)' : 'currentColor'}
-								strokeOpacity={isBooxConnectionEnabled ? 1 : 0.5}
-								strokeWidth={guideLineStrokeWidth}
-							/>
-						));
+						return Array.from({ length: lineCount }, (_, i) => {
+							const lineY = (i + 1) * lh;
+							// Cull guide lines the same way as strokes — render-only, page height unchanged.
+							if (visiblePageRect === null) return null;
+							if (
+								visiblePageRect !== undefined
+								&& (lineY < visiblePageRect.minY || lineY > visiblePageRect.maxY)
+							) {
+								return null;
+							}
+							return (
+								<line
+									key={i}
+									className="ink-writing-guide-line"
+									x1={margin}
+									y1={lineY}
+									x2={pw - margin}
+									y2={lineY}
+									stroke={isBooxConnectionEnabled ? 'var(--text-normal)' : 'currentColor'}
+									strokeOpacity={isBooxConnectionEnabled ? 1 : 0.5}
+									strokeWidth={guideLineStrokeWidth}
+								/>
+							);
+						});
 					})()}
-					{/* Committed strokes */}
+					{/* Committed strokes — store keeps all; only visible (or selected) mount as SVG */}
 					{strokes.map(stroke => (
-						<StrokePath
-							key={stroke.id}
-							stroke={stroke}
-							isSelected={selectedIds.has(stroke.id)}
-						/>
+						isStrokeVisibleInViewport(stroke) ? (
+							<StrokePath
+								key={stroke.id}
+								stroke={stroke}
+								isSelected={selectedIds.has(stroke.id)}
+							/>
+						) : null
 					))}
 
 					{/* Live stroke (in-progress, drawn imperatively) */}

--- a/src/ink-canvas/stroke-viewport-culling.ts
+++ b/src/ink-canvas/stroke-viewport-culling.ts
@@ -1,0 +1,80 @@
+import { screenToPage } from './camera';
+import type { CameraState, InkStroke } from './types';
+
+////////
+////////
+
+/** Axis-aligned rectangle in page/canvas space. */
+export type PageRect = {
+	minX: number;
+	minY: number;
+	maxX: number;
+	maxY: number;
+};
+
+/**
+ * Cheap page-space bounds for viewport culling only.
+ * Uses input points + size padding instead of perfect-freehand outlines so
+ * pan/scroll does not pay getStroke for every stroke just to decide visibility.
+ * Storage and StrokeStore are never filtered by this helper.
+ */
+export function computeApproxStrokePageBounds(stroke: InkStroke): PageRect {
+	let minX = Infinity;
+	let minY = Infinity;
+	let maxX = -Infinity;
+	let maxY = -Infinity;
+
+	for (const [px, py] of stroke.points) {
+		if (px < minX) minX = px;
+		if (py < minY) minY = py;
+		if (px > maxX) maxX = px;
+		if (py > maxY) maxY = py;
+	}
+
+	if (!Number.isFinite(minX)) {
+		return { minX: 0, minY: 0, maxX: 0, maxY: 0 };
+	}
+
+	// Pad by stroke size so outline expansion / thinning still intersects correctly.
+	const pad = Math.max(stroke.style.size, 1);
+	return {
+		minX: minX + stroke.offset.x - pad,
+		minY: minY + stroke.offset.y - pad,
+		maxX: maxX + stroke.offset.x + pad,
+		maxY: maxY + stroke.offset.y + pad,
+	};
+}
+
+export function pageRectsIntersect(a: PageRect, b: PageRect): boolean {
+	return a.minX <= b.maxX && a.maxX >= b.minX && a.minY <= b.maxY && a.maxY >= b.minY;
+}
+
+/**
+ * Page-space rect for the portion of the canvas container that is actually on screen
+ * (container ∩ browser viewport), with a screen-pixel margin for scroll hysteresis.
+ * Returns null when the container is fully off-screen — callers should cull all strokes.
+ */
+export function visiblePageRectFromContainer(
+	camera: CameraState,
+	containerRect: DOMRect,
+	marginScreenPx: number = 80,
+): PageRect | null {
+	const visibleLeft = Math.max(containerRect.left, 0) - marginScreenPx;
+	const visibleTop = Math.max(containerRect.top, 0) - marginScreenPx;
+	const visibleRight = Math.min(containerRect.right, window.innerWidth) + marginScreenPx;
+	const visibleBottom = Math.min(containerRect.bottom, window.innerHeight) + marginScreenPx;
+
+	if (visibleRight <= visibleLeft || visibleBottom <= visibleTop) {
+		return null;
+	}
+
+	const topLeft = screenToPage(camera, containerRect, visibleLeft, visibleTop);
+	const bottomRight = screenToPage(camera, containerRect, visibleRight, visibleBottom);
+
+	return {
+		minX: Math.min(topLeft.x, bottomRight.x),
+		minY: Math.min(topLeft.y, bottomRight.y),
+		maxX: Math.max(topLeft.x, bottomRight.x),
+		maxY: Math.max(topLeft.y, bottomRight.y),
+	};
+}

--- a/src/ink-canvas/stroke-viewport-culling.ts
+++ b/src/ink-canvas/stroke-viewport-culling.ts
@@ -50,6 +50,21 @@ export function pageRectsIntersect(a: PageRect, b: PageRect): boolean {
 }
 
 /**
+ * Cheap page-space content bottom for writing page-height / grow math.
+ * Uses the same approx AABBs as culling (points + size pad) so store updates do not
+ * pay getStroke for every stroke. Biases high vs outline bounds — empty buffer space is fine.
+ * Persistence/export still use full outline bounds where a tight fit is required.
+ */
+export function computeApproxContentMaxY(strokes: InkStroke[]): number {
+	let maxY = 0;
+	for (const stroke of strokes) {
+		const bounds = computeApproxStrokePageBounds(stroke);
+		if (bounds.maxY > maxY) maxY = bounds.maxY;
+	}
+	return maxY;
+}
+
+/**
  * Page-space rect for the portion of the canvas container that is actually on screen
  * (container ∩ browser viewport), with a screen-pixel margin for scroll hysteresis.
  * Returns null when the container is fully off-screen — callers should cull all strokes.

--- a/src/logic/utils/restore-embed-cm-scroller-scroll.ts
+++ b/src/logic/utils/restore-embed-cm-scroller-scroll.ts
@@ -1,17 +1,18 @@
 /**
- * Restores Obsidian's `.cm-scroller` after FingerBlocker scroll-pin or embed pan/zoom.
+ * Restores Obsidian's `.cm-scroller` or the dedicated writing scroller after FingerBlocker scroll-pin.
  * Mirrors release_0.5 `restoreEmbedScroll()` in tldraw-drawing-editor.
  */
 export function restoreEmbedCmScrollerScroll(wrapperEl: HTMLElement | null | undefined): void {
 	if (!wrapperEl) return;
-	const cmScroller = wrapperEl.closest<HTMLElement>('.cm-scroller');
-	if (!cmScroller) return;
-	cmScroller.classList.remove('ink-cm-scroller--scroll-pinned');
+	const scroller = wrapperEl.closest<HTMLElement>('.cm-scroller')
+		?? wrapperEl.closest<HTMLElement>('.ddc_ink_writing-dedicated-scroller');
+	if (!scroller) return;
+	scroller.classList.remove('ink-cm-scroller--scroll-pinned');
 	// Functional scroll-lock teardown (not theme styling); kept inline to avoid flash on unpin.
 	// eslint-disable-next-line obsidianmd/no-static-styles-assignment -- functional pen scroll-lock
-	cmScroller.style.overflow = 'auto';
+	scroller.style.overflow = 'auto';
 	window.setTimeout(() => {
 		// eslint-disable-next-line obsidianmd/no-static-styles-assignment -- functional pen scroll-lock
-		cmScroller.style.scrollbarColor = 'auto';
+		scroller.style.scrollbarColor = 'auto';
 	}, 200);
 }

--- a/tests/logic/touch-gesture-policy.test.ts
+++ b/tests/logic/touch-gesture-policy.test.ts
@@ -37,6 +37,16 @@ describe('touch-gesture-policy', () => {
 			).toBe('dedicatedWritingVertical');
 		});
 
+		it('returns embedNoteScroll for dedicated writing without camera pan (tall HTML scroller)', () => {
+			expect(
+				resolveInkTouchGestureMode({
+					writingMode: true,
+					isEmbedded: false,
+					hasDedicatedVerticalTouchPan: false,
+				}),
+			).toBe('embedNoteScroll');
+		});
+
 		it('returns inkCanvasTwoFinger for drawing', () => {
 			expect(
 				resolveInkTouchGestureMode({


### PR DESCRIPTION
## Summary

- Live writing/drawing canvases (embeds + dedicated views) skip mounting SVG paths for strokes fully outside the on-screen viewport, and remount them as camera/note scroll brings them back.
- Culling is render-only: `StrokeStore`, snapshots, and SVG file export still keep every stroke so saves cannot drop off-screen ink.
- Writing guide lines use the same viewport filter; selected strokes stay mounted for select-tool DOM moves.

## ClickUp

- [Improve performance while writing](https://app.clickup.com/t/86d3p8gt3) - `86d3p8gt3`

## Test plan

- [x] `npm run build` (tsc + esbuild)
- [ ] Write/draw a long page, then scroll — off-screen strokes should not keep slowing interaction; scrolling back should show them again
- [ ] Save and reopen — all strokes still present in the file
- [ ] Select and move strokes near the viewport edge still works

## Stack

Base: `release_0.5`
Depends on: none

Made with [Cursor](https://cursor.com)