### PR TITLE
Improve large Ink canvas performance

### DIFF
--- a/src/components/formats/current/drawing/drawing-editor/drawing-editor.tsx
+++ b/src/components/formats/current/drawing/drawing-editor/drawing-editor.tsx
@@ -1,13 +1,13 @@
 import './drawing-editor.scss';
 import * as React from 'react';
 import { useRef } from 'react';
-import { TFile } from 'obsidian';
+import { Platform, TFile } from 'obsidian';
 import { useAtomValue } from 'jotai';
 import classNames from 'classnames';
 import { InkFileData } from 'src/components/formats/current/types/file-data';
 import { buildInkCanvasDrawingFileData } from 'src/components/formats/current/utils/build-file-data';
 import { isInkCanvasFile } from 'src/components/formats/current/utils/ink-file-storage-engine';
-import { DRAW_SHORT_DELAY_MS, DRAW_LONG_DELAY_MS } from 'src/constants';
+import { DRAW_LONG_DELAY_MS, DRAW_SHORT_DELAY_MS } from 'src/constants';
 import { PrimaryMenuBar } from 'src/components/jsx-components/primary-menu-bar/primary-menu-bar';
 import { InkCanvasDrawingMenu } from 'src/components/jsx-components/drawing-menu/ink-canvas-drawing-menu';
 import ExtendedDrawingMenu from 'src/components/jsx-components/extended-drawing-menu/extended-drawing-menu';
@@ -32,6 +32,7 @@ import {
 } from 'src/logic/undo-redo/embedded-unified-undo';
 import { InkSvgCanvas } from 'src/ink-canvas/ink-svg-canvas';
 import { renderStrokesToSvg } from 'src/ink-canvas/svg-export';
+import { resolveInkAutosaveDelayMs } from 'src/ink-canvas/autosave-delay';
 import { migrateFromTldraw } from 'src/ink-canvas/migrate-from-tldraw';
 import { useDominantHand } from 'src/stores/dominant-hand-store';
 import { Notice } from 'obsidian';
@@ -102,7 +103,8 @@ export function DrawingEditor(props: DrawingEditorProps) {
 	const [isFingerDrawingActive, setIsFingerDrawingActive] = React.useState(false);
 	const [initialSnapshot, setInitialSnapshot] = React.useState<InkCanvasSnapshot>();
 	const shortDelayTimerRef = useRef<number>();
-	const longDelayTimerRef = useRef<number>();
+	const canvasInteractionActiveRef = useRef(false);
+	const hasUnsavedChangesRef = useRef(false);
 	const editorRef = useRef<InkCanvasEditor>();
 	const editorWrapperRefEl = useRef<HTMLDivElement>(null);
 	const websocketConnectedRef = useRef(false);
@@ -351,7 +353,17 @@ export function DrawingEditor(props: DrawingEditorProps) {
 	}
 
 	function handleStoreChange() {
+		hasUnsavedChangesRef.current = true;
 		queueSaves();
+	}
+
+	function handleCanvasInteractionChange(active: boolean) {
+		canvasInteractionActiveRef.current = active;
+		if (active) {
+			resetTimers();
+			return;
+		}
+		if (hasUnsavedChangesRef.current) queueSaves();
 	}
 
 	function handleEmbedUndoStackPush() {
@@ -366,15 +378,18 @@ export function DrawingEditor(props: DrawingEditorProps) {
 
 	function queueSaves() {
 		resetTimers();
+		if (canvasInteractionActiveRef.current) return;
+		const delayMs = resolveInkAutosaveDelayMs(Platform, DRAW_SHORT_DELAY_MS, DRAW_LONG_DELAY_MS);
 		shortDelayTimerRef.current = window.setTimeout(() => {
 			void incrementalSave();
-		}, DRAW_SHORT_DELAY_MS);
-		longDelayTimerRef.current = window.setTimeout(() => {
-			void completeSave();
-		}, DRAW_LONG_DELAY_MS);
+		}, delayMs);
 	}
 
 	async function incrementalSave() {
+		if (canvasInteractionActiveRef.current) {
+			queueSaves();
+			return;
+		}
 		const editor = editorRef.current;
 		if (!editor) return;
 		verbose('incrementalSave (ink-canvas)');
@@ -382,6 +397,7 @@ export function DrawingEditor(props: DrawingEditorProps) {
 
 		const snapshot = editor.getSnapshot();
 		const svgString = renderStrokesToSvg(snapshot.strokes, snapshot);
+		hasUnsavedChangesRef.current = false;
 		const fileData = buildInkCanvasDrawingFileData({
 			inkCanvasSnapshot: snapshot,
 			svgString,
@@ -397,6 +413,7 @@ export function DrawingEditor(props: DrawingEditorProps) {
 
 		const snapshot = editor.getSnapshot();
 		const svgString = renderStrokesToSvg(snapshot.strokes, snapshot);
+		hasUnsavedChangesRef.current = false;
 		const fileData = buildInkCanvasDrawingFileData({
 			inkCanvasSnapshot: snapshot,
 			svgString,
@@ -406,7 +423,6 @@ export function DrawingEditor(props: DrawingEditorProps) {
 
 	function resetTimers() {
 		window.clearTimeout(shortDelayTimerRef.current);
-		window.clearTimeout(longDelayTimerRef.current);
 	}
 
 
@@ -754,6 +770,7 @@ export function DrawingEditor(props: DrawingEditorProps) {
 				initialSnapshot={initialSnapshot}
 				onEditorReady={handleEditorReady}
 				onChange={handleStoreChange}
+				onInteractionChange={handleCanvasInteractionChange}
 				onEmbedUndoStackPush={handleEmbedUndoStackPush}
 				onCameraChange={(camera, containerRect, meta) => {
 					if (meta.source === 'user') hasUserMovedCameraRef.current = true;

--- a/src/components/formats/current/utils/buildFileStr.ts
+++ b/src/components/formats/current/utils/buildFileStr.ts
@@ -20,42 +20,43 @@ export const buildFileStr = (pageData: InkFileData): string => {
 //////////////////////////
 
 function buildInkCanvasFileStr(pageData: InkFileData): string {
-    // For ink-canvas files, the svgString already contains the full SVG with
-    // <ink-canvas> metadata (produced by svg-export.ts). We just need to ensure
-    // the <ink> meta element is present with plugin-version and file-type.
-    let fileStr = pageData.svgString || '<svg></svg>';
+    // The ink-canvas renderer already gives us a complete SVG. Re-parsing and
+    // pretty-printing that multi-megabyte document on every autosave blocks the
+    // input thread in direct proportion to the number of strokes. Replace just
+    // the small metadata block and keep the rendered path markup untouched.
+    const fileStr = pageData.svgString || '<svg></svg>';
+    const snapshotJson = escapeXmlText(JSON.stringify(pageData.inkCanvas));
+    const metadata = [
+        '<metadata>',
+        `<ink plugin-version="${escapeXmlAttribute(String(pageData.meta.pluginVersion))}" file-type="${escapeXmlAttribute(pageData.meta.fileType)}"/>`,
+        `<ink-canvas version="${escapeXmlAttribute(INK_CANVAS_FORMAT_VERSION)}">${snapshotJson}</ink-canvas>`,
+        '</metadata>',
+    ].join('\n');
 
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(fileStr, 'image/svg+xml');
-    const svgElement = doc.documentElement;
-
-    // Remove existing metadata to rebuild cleanly
-    const existingMetadata = svgElement.getElementsByTagName('metadata');
-    while (existingMetadata.length > 0) {
-        existingMetadata[0].parentNode?.removeChild(existingMetadata[0]);
+    const metadataPattern = /<metadata\b[^>]*>[\s\S]*?<\/metadata>/i;
+    if (metadataPattern.test(fileStr)) {
+        return fileStr.replace(metadataPattern, metadata);
     }
 
-    const metadataElement = doc.createElement('metadata');
+    const svgOpenPattern = /<svg\b[^>]*>/i;
+    if (svgOpenPattern.test(fileStr)) {
+        return fileStr.replace(svgOpenPattern, (svgOpen) => `${svgOpen}\n${metadata}`);
+    }
 
-    // <ink> meta
-    const inkMetaElement = doc.createElement('ink');
-    inkMetaElement.setAttribute('plugin-version', String(pageData.meta.pluginVersion));
-    inkMetaElement.setAttribute('file-type', pageData.meta.fileType);
-    metadataElement.appendChild(inkMetaElement);
+    return `<svg xmlns="http://www.w3.org/2000/svg">\n${metadata}\n</svg>`;
+}
 
-    // <ink-canvas version="0.5.0"> JSON </ink-canvas>
-    const inkCanvasElement = doc.createElement('ink-canvas');
-    inkCanvasElement.setAttribute('version', INK_CANVAS_FORMAT_VERSION);
-    inkCanvasElement.textContent = JSON.stringify(pageData.inkCanvas, null, 2);
-    metadataElement.appendChild(inkCanvasElement);
+function escapeXmlText(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
 
-    svgElement.appendChild(metadataElement);
-
-    const serializedSvg = new XMLSerializer().serializeToString(svgElement);
-    return format(serializedSvg, {
-        indentation: '\t',
-        lineSeparator: '\n'
-    });
+function escapeXmlAttribute(value: string): string {
+    return escapeXmlText(value)
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
 }
 
 

--- a/src/components/formats/current/writing/writing-editor/writing-editor.tsx
+++ b/src/components/formats/current/writing/writing-editor/writing-editor.tsx
@@ -1,7 +1,7 @@
 import './writing-editor.scss';
 import * as React from 'react';
 import { useRef } from 'react';
-import { TFile } from 'obsidian';
+import { Platform, TFile } from 'obsidian';
 import { useAtomValue } from 'jotai';
 import classNames from 'classnames';
 import InkPlugin from 'src/main';
@@ -39,6 +39,7 @@ import {
 } from 'src/logic/undo-redo/embedded-unified-undo';
 import { InkSvgCanvas } from 'src/ink-canvas/ink-svg-canvas';
 import { renderWritingStrokesToSvg } from 'src/ink-canvas/svg-export';
+import { resolveInkAutosaveDelayMs } from 'src/ink-canvas/autosave-delay';
 import { computeApproxContentMaxY } from 'src/ink-canvas/stroke-viewport-culling';
 import { migrateWritingFromTldraw } from 'src/ink-canvas/migrate-from-tldraw';
 import type { PageBounds } from './page-bounds';
@@ -107,7 +108,9 @@ export function WritingEditor(props: WritingEditorProps) {
 	const [booxConnected, setBooxConnected] = React.useState(false);
 	const resizePostProcessTimeoutRef = useRef<number>();
 	const shortDelayTimerRef = useRef<number>();
-	const longDelayTimerRef = useRef<number>();
+	const canvasInteractionActiveRef = useRef(false);
+	const hasUnsavedChangesRef = useRef(false);
+	const latestInvitingHeightRef = useRef(0);
 	const editorRef = useRef<InkCanvasEditor>();
 	const editorWrapperRefEl = useRef<HTMLDivElement>(null);
 	const websocketConnectedRef = useRef(false);
@@ -459,10 +462,20 @@ export function WritingEditor(props: WritingEditorProps) {
 	}
 
 	function handleStoreChange() {
+		hasUnsavedChangesRef.current = true;
 		queueSaves();
 		if (props.embedded) {
 			debouncedEmbedResizePostProcess();
 		}
+	}
+
+	function handleCanvasInteractionChange(active: boolean) {
+		canvasInteractionActiveRef.current = active;
+		if (active) {
+			resetTimers();
+			return;
+		}
+		if (hasUnsavedChangesRef.current) queueSaves();
 	}
 
 	function handleEmbedUndoStackPush() {
@@ -485,7 +498,7 @@ export function WritingEditor(props: WritingEditorProps) {
 			const editor = editorRef.current;
 			if (!editor || !props.embedded) return;
 			if (websocketConnectedRef.current && getBooxConnectionEnabled()) return;
-			const invitingHeight = getInvitingHeightFromEditor(editor);
+			const invitingHeight = latestInvitingHeightRef.current || getInvitingHeightFromEditor(editor);
 			if (!shouldResizeForNewHeight(
 				invitingHeight,
 				curHeightRef.current,
@@ -499,6 +512,7 @@ export function WritingEditor(props: WritingEditorProps) {
 	}
 
 	function handlePageHeightChange(candidateHeightPx: number) {
+		latestInvitingHeightRef.current = candidateHeightPx;
 		applyPageHeightChange(candidateHeightPx, false);
 	}
 
@@ -508,7 +522,10 @@ export function WritingEditor(props: WritingEditorProps) {
 
 		const lineHeight = writingLineHeightRef.current;
 		const bufferLines = props.plugin.settings.writingBufferLines;
-		const invitingFromContent = getInvitingHeightFromEditor(editor);
+		const invitingFromContent = candidateHeightPx > 0
+			? candidateHeightPx
+			: getInvitingHeightFromEditor(editor);
+		latestInvitingHeightRef.current = invitingFromContent;
 
 		if (props.embedded) {
 			const skipAutoResize = !forceNextPageHeightChangeRef.current
@@ -587,20 +604,24 @@ export function WritingEditor(props: WritingEditorProps) {
 
 	function queueSaves() {
 		resetTimers();
+		if (canvasInteractionActiveRef.current) return;
+		const delayMs = resolveInkAutosaveDelayMs(Platform, WRITE_SHORT_DELAY_MS, WRITE_LONG_DELAY_MS);
 		shortDelayTimerRef.current = window.setTimeout(() => {
 			void incrementalSave();
-		}, WRITE_SHORT_DELAY_MS);
-		longDelayTimerRef.current = window.setTimeout(() => {
-			void completeSave();
-		}, WRITE_LONG_DELAY_MS);
+		}, delayMs);
 	}
 
 	async function incrementalSave() {
+		if (canvasInteractionActiveRef.current) {
+			queueSaves();
+			return;
+		}
 		const editor = editorRef.current;
 		if (!editor) return;
 		verbose('incrementalSave (ink-canvas writing)');
 		const snapshot = editor.getSnapshot();
 		const svgString = renderWritingStrokesToSvg(snapshot.strokes, snapshot, WRITING_PAGE_WIDTH);
+		hasUnsavedChangesRef.current = false;
 		props.save(buildInkCanvasWritingFileData({ inkCanvasSnapshot: snapshot, svgString }));
 	}
 
@@ -610,13 +631,13 @@ export function WritingEditor(props: WritingEditorProps) {
 		verbose('completeSave (ink-canvas writing)');
 		const snapshot = editor.getSnapshot();
 		const svgString = renderWritingStrokesToSvg(snapshot.strokes, snapshot, WRITING_PAGE_WIDTH);
+		hasUnsavedChangesRef.current = false;
 		props.save(buildInkCanvasWritingFileData({ inkCanvasSnapshot: snapshot, svgString }));
 	}
 
 	function resetTimers() {
 		cancelDelayedBooxResizePostProcess();
 		window.clearTimeout(shortDelayTimerRef.current);
-		window.clearTimeout(longDelayTimerRef.current);
 	}
 
 	async function fetchFileData() {
@@ -929,6 +950,7 @@ export function WritingEditor(props: WritingEditorProps) {
 			writingBufferLines={props.plugin.settings.writingBufferLines}
 			onEditorReady={handleEditorReady}
 			onChange={handleStoreChange}
+			onInteractionChange={handleCanvasInteractionChange}
 			onEmbedUndoStackPush={handleEmbedUndoStackPush}
 			onPageHeightChange={handlePageHeightChange}
 			isEmbedded={props.embedded}

--- a/src/ink-canvas/autosave-delay.ts
+++ b/src/ink-canvas/autosave-delay.ts
@@ -1,0 +1,16 @@
+export type InkPlatformFlags = {
+	isMobile?: boolean;
+	isMobileApp?: boolean;
+	isIosApp?: boolean;
+};
+
+/** Mobile WebViews need a longer quiet period before serializing large Ink SVGs. */
+export function resolveInkAutosaveDelayMs(
+	platform: InkPlatformFlags,
+	desktopDelayMs: number,
+	mobileDelayMs: number,
+): number {
+	return platform.isMobile || platform.isMobileApp || platform.isIosApp
+		? mobileDelayMs
+		: desktopDelayMs;
+}

--- a/src/ink-canvas/ink-svg-canvas.tsx
+++ b/src/ink-canvas/ink-svg-canvas.tsx
@@ -1,8 +1,6 @@
 import './ink-svg-canvas.scss';
 import React, { useEffect, useLayoutEffect, useRef, useCallback, useState, memo } from 'react';
-import { getStroke } from 'perfect-freehand';
-import { getSvgPathFromStroke } from './utils/svg-path-from-stroke';
-import { StrokeStore } from './stroke-store';
+import { StrokeStore, type StrokeStoreChange } from './stroke-store';
 import { UndoManager } from './undo-manager';
 import { panByScreenDelta, zoomAtPoint, clampZoom, fitBoundsToViewport, adjustCameraToPreservePagePointAtScreenTargets, adjustCameraToPreserveViewportCenter, screenToPage as screenToPageFn, getRightDragZoomDelta } from './camera';
 import { createPanMomentumController, createModifierWheelZoomDirectionResolver, isTrackpadWheel, type PanMomentumController } from './pan-momentum';
@@ -28,12 +26,13 @@ import { useStrokeInputTreatAs } from 'src/logic/device-settings/use-stroke-inpu
 import { useResolvedStrokeInputTreatAs } from 'src/logic/device-settings/use-resolved-stroke-input-treat-as';
 import { useBooxConnectionEnabled } from 'src/logic/device-settings/use-boox-connection-enabled';
 import { DEFAULT_SETTINGS } from 'src/types/plugin-settings';
-import { toStrokeOptions, DEFAULT_STROKE_STYLE } from './types';
+import { DEFAULT_STROKE_STYLE } from './types';
 import type { InkTool, InkStrokeStyle, CameraState, InkCanvasSnapshot, InkCanvasEditor, InkStroke } from './types';
 import type { DrawToolContext } from './tools/draw-tool';
 import type { EraseToolContext } from './tools/erase-tool';
 import type { SelectToolContext } from './tools/select-tool';
 import { InkAdaptiveGrid, INK_GRID_BOOX_ZOOM_FADE_SCALE } from './ink-adaptive-grid';
+import { getRenderedStrokeData } from './rendered-stroke-cache';
 
 type LastCanvasPointerState = {
 	clientX: number;
@@ -66,6 +65,8 @@ export interface InkSvgCanvasProps {
 	initialSnapshot?: InkCanvasSnapshot;
 	onEditorReady?: (editor: InkCanvasEditor) => void;
 	onChange?: () => void;
+	/** Pauses expensive persistence work while a pen/pointer interaction is active. */
+	onInteractionChange?: (active: boolean) => void;
 	/** Fired when a new undoable canvas command is executed (stroke, erase, move, etc.). */
 	onEmbedUndoStackPush?: () => void;
 	/** Emits whenever camera changes (pan/zoom/setCamera). */
@@ -111,6 +112,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 	const pageWidth = props.pageWidth ?? WRITING_PAGE_WIDTH;
 	const writingBufferLines = props.writingBufferLines ?? 3;
 	const writingLineHeight = props.initialSnapshot?.writingLineHeight ?? WRITING_LINE_HEIGHT;
+	const contentMaxYRef = useRef(0);
 
 	const canvasWrapperRef = useRef<HTMLDivElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -124,6 +126,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 		const contentHeight = strokes.length > 0
 			? computeApproxContentMaxY(strokes)
 			: 0;
+		contentMaxYRef.current = contentHeight;
 		return cropWritingStrokeHeightInvitingly(contentHeight, writingBufferLines, writingLineHeight);
 	}
 
@@ -180,6 +183,8 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 	gridEnabledRef.current = gridEnabled;
 	const onChangeRef = useRef(props.onChange);
 	onChangeRef.current = props.onChange;
+	const onInteractionChangeRef = useRef(props.onInteractionChange);
+	onInteractionChangeRef.current = props.onInteractionChange;
 	const onEmbedUndoStackPushRef = useRef(props.onEmbedUndoStackPush);
 	onEmbedUndoStackPushRef.current = props.onEmbedUndoStackPush;
 	const setGridEnabledHandlerRef = useRef<(enabled: boolean) => void>(() => {});
@@ -306,21 +311,29 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 
 	// Subscribe to store changes to re-render strokes
 	useEffect(() => {
-		const unsubStore = storeRef.current.subscribe(() => {
-			// Invalidate cull bounds + path `d` — points/style may have changed; store still holds every stroke.
-			strokeBoundsCacheRef.current.clear();
-			strokePathDCacheRef.current.clear();
+		const unsubStore = storeRef.current.subscribe((change) => {
+			// Only invalidate cache entries touched by this mutation.
+			invalidateStrokeCaches(change);
 			forceRender(n => n + 1);
 			props.onChange?.();
 
 			if (writingMode) {
-				const allStrokes = storeRef.current.getAll();
+				if (change.type === 'add' || change.type === 'addMany') {
+					for (const id of change.ids) {
+						const stroke = storeRef.current.getById(id);
+						if (!stroke) continue;
+						const bounds = computeApproxStrokePageBounds(stroke);
+						strokeBoundsCacheRef.current.set(id, bounds);
+						if (bounds.maxY > contentMaxYRef.current) contentMaxYRef.current = bounds.maxY;
+					}
+				} else if (change.type === 'clear') {
+					contentMaxYRef.current = 0;
+				} else {
+					contentMaxYRef.current = computeApproxContentMaxY(storeRef.current.getAll());
+				}
 				const lh = props.initialSnapshot?.writingLineHeight ?? WRITING_LINE_HEIGHT;
-				const contentHeight = allStrokes.length > 0
-					? computeApproxContentMaxY(allStrokes)
-					: 0;
 				const candidateHeight = cropWritingStrokeHeightInvitingly(
-					contentHeight,
+					contentMaxYRef.current,
 					writingBufferLines,
 					lh,
 				);
@@ -335,6 +348,20 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 		});
 		return () => { unsubStore(); unsubUndo(); };
 	}, []);  
+
+	function invalidateStrokeCaches(change: StrokeStoreChange): void {
+		if (change.type === 'clear' || change.type === 'replaceAll') {
+			strokeBoundsCacheRef.current.clear();
+			strokePathDCacheRef.current.clear();
+			return;
+		}
+
+		for (const id of change.ids) {
+			strokeBoundsCacheRef.current.delete(id);
+			// Moving a stroke only changes its transform; its path data stays valid.
+			if (change.type !== 'updateOffsets') strokePathDCacheRef.current.delete(id);
+		}
+	}
 
 	// Re-cull when the note scroller or window moves the canvas on/off screen (embeds + dedicated).
 	useEffect(() => {
@@ -725,6 +752,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 		// Touch input: two-finger gestures are handled by the native touch listener.
 		// Single-finger touch is ignored unless finger drawing is active.
 		if (e.pointerType === 'touch' && !isFingerDrawingActiveRef.current) return;
+		onInteractionChangeRef.current?.(true);
 
 		recordCanvasPointer(e);
 		isPointerOverCanvasRef.current = true;
@@ -847,6 +875,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 
 	const handlePointerUp = useCallback((e: React.PointerEvent) => {
 		if (e.pointerType === 'touch' && !isFingerDrawingActiveRef.current) return;
+		onInteractionChangeRef.current?.(false);
 
 		recordCanvasPointer(e);
 
@@ -878,6 +907,7 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 
 	const handlePointerCancel = useCallback((e: React.PointerEvent) => {
 		if (e.pointerType === 'touch' && !isFingerDrawingActiveRef.current) return;
+		onInteractionChangeRef.current?.(false);
 
 		recordCanvasPointer(e);
 
@@ -1303,8 +1333,7 @@ const StrokePath = memo(function StrokePath(props: StrokePathProps): React.JSX.E
 	// cache clear + remount) reuse `d` when the id is still populated; offset is transform-only.
 	let d = pathDCache.get(stroke.id);
 	if (d === undefined) {
-		const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
-		d = getSvgPathFromStroke(outlinePoints);
+		d = getRenderedStrokeData(stroke).pathD;
 		pathDCache.set(stroke.id, d);
 	}
 

--- a/src/ink-canvas/rendered-stroke-cache.ts
+++ b/src/ink-canvas/rendered-stroke-cache.ts
@@ -1,0 +1,48 @@
+import { getStroke } from 'perfect-freehand';
+import type { InkStroke } from './types';
+import { toStrokeOptions } from './types';
+import { getSvgPathFromStroke } from './utils/svg-path-from-stroke';
+
+export type RenderedStrokeBounds = {
+	minX: number;
+	minY: number;
+	maxX: number;
+	maxY: number;
+};
+
+export type RenderedStrokeData = {
+	pathD: string;
+	bounds: RenderedStrokeBounds;
+};
+
+// Strokes are immutable in normal use. A WeakMap lets editor rendering and
+// autosave share the expensive perfect-freehand outline without retaining
+// deleted strokes.
+const renderedStrokeCache = new WeakMap<InkStroke, RenderedStrokeData>();
+
+export function getRenderedStrokeData(stroke: InkStroke): RenderedStrokeData {
+	const cached = renderedStrokeCache.get(stroke);
+	if (cached) return cached;
+
+	const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
+	let minX = Infinity;
+	let minY = Infinity;
+	let maxX = -Infinity;
+	let maxY = -Infinity;
+
+	for (const [x, y] of outlinePoints) {
+		if (x < minX) minX = x;
+		if (y < minY) minY = y;
+		if (x > maxX) maxX = x;
+		if (y > maxY) maxY = y;
+	}
+
+	const data: RenderedStrokeData = {
+		pathD: getSvgPathFromStroke(outlinePoints),
+		bounds: Number.isFinite(minX)
+			? { minX, minY, maxX, maxY }
+			: { minX: 0, minY: 0, maxX: 0, maxY: 0 },
+	};
+	renderedStrokeCache.set(stroke, data);
+	return data;
+}

--- a/src/ink-canvas/stroke-store.ts
+++ b/src/ink-canvas/stroke-store.ts
@@ -3,7 +3,11 @@ import type { InkStroke } from './types';
 ///////////////////////////
 ///////////////////////////
 
-export type StrokeStoreListener = () => void;
+export type StrokeStoreChange =
+	| { type: 'add' | 'addMany' | 'remove' | 'updateOffsets'; ids: string[] }
+	| { type: 'clear' | 'replaceAll'; ids: [] };
+
+export type StrokeStoreListener = (change: StrokeStoreChange) => void;
 
 /**
  * Reactive store for ink strokes. Maintains an ordered list of strokes and
@@ -20,16 +24,16 @@ export class StrokeStore {
 		return () => { this.listeners.delete(listener); };
 	}
 
-	private notify(): void {
+	private notify(change: StrokeStoreChange): void {
 		for (const listener of this.listeners) {
-			listener();
+			listener(change);
 		}
 	}
 
 	add(stroke: InkStroke): void {
 		this.strokes.set(stroke.id, stroke);
 		this.insertionOrder.push(stroke.id);
-		this.notify();
+		this.notify({ type: 'add', ids: [stroke.id] });
 	}
 
 	addMany(strokesArr: InkStroke[]): void {
@@ -37,7 +41,7 @@ export class StrokeStore {
 			this.strokes.set(stroke.id, stroke);
 			this.insertionOrder.push(stroke.id);
 		}
-		this.notify();
+		this.notify({ type: 'addMany', ids: strokesArr.map((stroke) => stroke.id) });
 	}
 
 	remove(ids: string[]): void {
@@ -46,7 +50,7 @@ export class StrokeStore {
 			this.strokes.delete(id);
 		}
 		this.insertionOrder = this.insertionOrder.filter(id => !idSet.has(id));
-		this.notify();
+		this.notify({ type: 'remove', ids: [...ids] });
 	}
 
 	/** Update the offset of one or more strokes (used by the select-and-move tool). */
@@ -57,7 +61,7 @@ export class StrokeStore {
 				this.strokes.set(id, { ...stroke, offset });
 			}
 		}
-		this.notify();
+		this.notify({ type: 'updateOffsets', ids: Array.from(offsets.keys()) });
 	}
 
 	getById(id: string): InkStroke | undefined {
@@ -82,7 +86,7 @@ export class StrokeStore {
 	clear(): void {
 		this.strokes.clear();
 		this.insertionOrder = [];
-		this.notify();
+		this.notify({ type: 'clear', ids: [] });
 	}
 
 	/** Replace all content with the given strokes (used for snapshot restore). */
@@ -93,6 +97,6 @@ export class StrokeStore {
 			this.strokes.set(stroke.id, stroke);
 			this.insertionOrder.push(stroke.id);
 		}
-		this.notify();
+		this.notify({ type: 'replaceAll', ids: [] });
 	}
 }

--- a/src/ink-canvas/svg-export.ts
+++ b/src/ink-canvas/svg-export.ts
@@ -1,4 +1,3 @@
-import { getStroke } from 'perfect-freehand';
 import {
 	DEFAULT_CONTENT_COLOUR_PRIMARY_STROKE,
 	DEFAULT_CONTENT_COLOUR_WRITING_LINE,
@@ -6,9 +5,8 @@ import {
 	INK_SVG_WRITING_LINE_CLASS,
 } from 'src/default-content-colours';
 import { INK_CANVAS_FORMAT_VERSION, WRITING_LINE_HEIGHT, WRITING_MIN_PAGE_HEIGHT } from 'src/constants';
-import { getSvgPathFromStroke } from './utils/svg-path-from-stroke';
 import type { InkStroke, InkCanvasSnapshot } from './types';
-import { toStrokeOptions } from './types';
+import { getRenderedStrokeData } from './rendered-stroke-cache';
 ///////////////////////////
 ///////////////////////////
 
@@ -26,7 +24,8 @@ export function renderStrokesToSvg(
 		return buildSvgString('', '0 0 1 1', snapshotJson);
 	}
 
-	const bounds = computeStrokesBounds(strokes);
+	const rendered = renderStrokePathsAndBounds(strokes);
+	const bounds = rendered.bounds;
 	const viewBox = [
 		bounds.minX - padding,
 		bounds.minY - padding,
@@ -34,14 +33,7 @@ export function renderStrokesToSvg(
 		bounds.height + padding * 2,
 	].join(' ');
 
-	let pathsMarkup = '';
-	for (const stroke of strokes) {
-		const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
-		const d = getSvgPathFromStroke(outlinePoints);
-		pathsMarkup += buildStrokePathMarkup(d, stroke.offset.x, stroke.offset.y);
-	}
-
-	return buildSvgString(pathsMarkup, viewBox, snapshotJson);
+	return buildSvgString(rendered.pathsMarkup, viewBox, snapshotJson);
 }
 
 /**
@@ -55,10 +47,10 @@ export function renderWritingStrokesToSvg(
 	padding: number = 0,
 ): string {
 	const lineHeight = snapshot.writingLineHeight ?? WRITING_LINE_HEIGHT;
+	const rendered = renderStrokePathsAndBounds(strokes);
 	let height = WRITING_MIN_PAGE_HEIGHT;
 	if (strokes.length > 0) {
-		const bounds = computeStrokesBounds(strokes);
-		const numFilledLines = Math.ceil((bounds.maxY + padding) / lineHeight);
+		const numFilledLines = Math.ceil((rendered.bounds.maxY + padding) / lineHeight);
 		height = Math.max((numFilledLines + 0.5) * lineHeight, WRITING_MIN_PAGE_HEIGHT);
 	}
 
@@ -70,15 +62,8 @@ export function renderWritingStrokesToSvg(
 		guideMarkup += `<line x1="${margin}" y1="${y}" x2="${pageWidth - margin}" y2="${y}" stroke="${DEFAULT_CONTENT_COLOUR_WRITING_LINE}" stroke-opacity="0.5" class="${INK_SVG_WRITING_LINE_CLASS}" />\n`;
 	}
 
-	let pathsMarkup = '';
-	for (const stroke of strokes) {
-		const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
-		const d = getSvgPathFromStroke(outlinePoints);
-		pathsMarkup += buildStrokePathMarkup(d, stroke.offset.x, stroke.offset.y);
-	}
-
 	const viewBox = `0 0 ${pageWidth} ${height}`;
-	return buildSvgString(guideMarkup + pathsMarkup, viewBox, snapshot);
+	return buildSvgString(guideMarkup + rendered.pathsMarkup, viewBox, snapshot);
 }
 
 
@@ -104,19 +89,47 @@ function buildSvgString(
 	return [
 		`<svg xmlns="http://www.w3.org/2000/svg" viewBox="${viewBox}">`,
 		`<metadata>`,
-		`<ink-canvas version="${INK_CANVAS_FORMAT_VERSION}">${escapeXml(metadataJson)}</ink-canvas>`,
+		`<ink-canvas version="${INK_CANVAS_FORMAT_VERSION}">${escapeXmlText(metadataJson)}</ink-canvas>`,
 		`</metadata>`,
 		pathsMarkup,
 		`</svg>`,
 	].join('\n');
 }
 
-function escapeXml(str: string): string {
+function escapeXmlText(str: string): string {
 	return str
 		.replace(/&/g, '&amp;')
 		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;');
+		.replace(/>/g, '&gt;');
+}
+
+function renderStrokePathsAndBounds(strokes: InkStroke[]): {
+	pathsMarkup: string;
+	bounds: StrokeBounds;
+} {
+	let minX = Infinity;
+	let minY = Infinity;
+	let maxX = -Infinity;
+	let maxY = -Infinity;
+	let pathsMarkup = '';
+
+	for (const stroke of strokes) {
+		const rendered = getRenderedStrokeData(stroke);
+		const strokeMinX = rendered.bounds.minX + stroke.offset.x;
+		const strokeMinY = rendered.bounds.minY + stroke.offset.y;
+		const strokeMaxX = rendered.bounds.maxX + stroke.offset.x;
+		const strokeMaxY = rendered.bounds.maxY + stroke.offset.y;
+		if (strokeMinX < minX) minX = strokeMinX;
+		if (strokeMinY < minY) minY = strokeMinY;
+		if (strokeMaxX > maxX) maxX = strokeMaxX;
+		if (strokeMaxY > maxY) maxY = strokeMaxY;
+		pathsMarkup += buildStrokePathMarkup(rendered.pathD, stroke.offset.x, stroke.offset.y);
+	}
+
+	return {
+		pathsMarkup,
+		bounds: { minX, minY, maxX, maxY, width: maxX - minX, height: maxY - minY },
+	};
 }
 
 
@@ -139,17 +152,15 @@ export function computeStrokesBounds(strokes: InkStroke[]): StrokeBounds {
 	let maxY = -Infinity;
 
 	for (const stroke of strokes) {
-		// Compute the outline to get the true rendered bounds
-		const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
-
-		for (const [px, py] of outlinePoints) {
-			const x = px + stroke.offset.x;
-			const y = py + stroke.offset.y;
-			if (x < minX) minX = x;
-			if (y < minY) minY = y;
-			if (x > maxX) maxX = x;
-			if (y > maxY) maxY = y;
-		}
+		const rendered = getRenderedStrokeData(stroke);
+		const strokeMinX = rendered.bounds.minX + stroke.offset.x;
+		const strokeMinY = rendered.bounds.minY + stroke.offset.y;
+		const strokeMaxX = rendered.bounds.maxX + stroke.offset.x;
+		const strokeMaxY = rendered.bounds.maxY + stroke.offset.y;
+		if (strokeMinX < minX) minX = strokeMinX;
+		if (strokeMinY < minY) minY = strokeMinY;
+		if (strokeMaxX > maxX) maxX = strokeMaxX;
+		if (strokeMaxY > maxY) maxY = strokeMaxY;
 	}
 
 	return {

--- a/tests/components/formats/current/utils/BuildFileStr.test.ts
+++ b/tests/components/formats/current/utils/BuildFileStr.test.ts
@@ -3,6 +3,7 @@ import { buildFileStr } from 'src/components/formats/current/utils/buildFileStr'
 import { extractInkJsonFromSvg } from 'src/logic/utils/extractInkJsonFromSvg';
 import { InkFileData } from 'src/components/formats/current/types/file-data';
 import { PLUGIN_VERSION, TLDRAW_VERSION } from 'src/constants';
+import { DEFAULT_STROKE_STYLE, type InkCanvasSnapshot } from 'src/ink-canvas/types';
 
 ////////
 ////////
@@ -34,6 +35,30 @@ function makeDrawingFileData(): InkFileData {
 		},
 		tldraw: minimalSnapshot,
 		svgString: '<svg xmlns="http://www.w3.org/2000/svg"><defs/></svg>',
+	};
+}
+
+function makeInkCanvasFileData(): InkFileData {
+	const inkCanvas: InkCanvasSnapshot = {
+		version: 1,
+		strokes: [{
+			id: 'stroke<&',
+			points: [[0, 0, 0.5], [10, 10, 0.7]],
+			style: { ...DEFAULT_STROKE_STYLE },
+			offset: { x: 0, y: 0 },
+		}],
+		gridEnabled: false,
+		writingLineHeight: 150,
+	};
+	return {
+		meta: {
+			pluginVersion: PLUGIN_VERSION,
+			tldrawVersion: '',
+			fileType: 'inkWriting',
+		},
+		tldraw: minimalSnapshot,
+		inkCanvas,
+		svgString: '<svg xmlns="http://www.w3.org/2000/svg"><metadata><ink-canvas>stale</ink-canvas></metadata><path id="kept"/></svg>',
 	};
 }
 
@@ -73,6 +98,27 @@ describe('buildFileStr — writing-line-height attribute', () => {
 	test('always includes the tldraw element', () => {
 		const result = buildFileStr(makeWritingFileData(150));
 		expect(result).toContain('<tldraw');
+	});
+});
+
+describe('buildFileStr — ink-canvas serialization', () => {
+	test('replaces only metadata and keeps rendered SVG markup intact', () => {
+		const result = buildFileStr(makeInkCanvasFileData());
+
+		expect(result.match(/<metadata\b/g)).toHaveLength(1);
+		expect(result).toContain('<path id="kept"/>');
+		expect(result).not.toContain('stale');
+	});
+
+	test('uses compact XML-safe JSON that survives a round trip', () => {
+		const result = buildFileStr(makeInkCanvasFileData());
+		const parsed = extractInkJsonFromSvg(result);
+
+		expect(result).toContain('"version":1');
+		expect(result).not.toContain('\n  "version"');
+		expect(result).toContain('stroke&lt;&amp;');
+		expect(parsed?.inkCanvas?.strokes[0].id).toBe('stroke<&');
+		expect(parsed?.inkCanvas?.writingLineHeight).toBe(150);
 	});
 });
 

--- a/tests/ink-canvas/autosave-delay.test.ts
+++ b/tests/ink-canvas/autosave-delay.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from '@jest/globals';
+import { resolveInkAutosaveDelayMs } from 'src/ink-canvas/autosave-delay';
+
+describe('resolveInkAutosaveDelayMs', () => {
+	test('keeps the short quiet period on desktop', () => {
+		expect(resolveInkAutosaveDelayMs({}, 500, 2000)).toBe(500);
+	});
+
+	test.each([
+		{ isMobile: true },
+		{ isMobileApp: true },
+		{ isIosApp: true },
+	])('uses the longer quiet period for mobile platform flag %#', (platform) => {
+		expect(resolveInkAutosaveDelayMs(platform, 500, 2000)).toBe(2000);
+	});
+});

--- a/tests/ink-canvas/rendered-stroke-cache.test.ts
+++ b/tests/ink-canvas/rendered-stroke-cache.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from '@jest/globals';
+import { getRenderedStrokeData } from 'src/ink-canvas/rendered-stroke-cache';
+import type { InkStroke } from 'src/ink-canvas/types';
+import { DEFAULT_STROKE_STYLE } from 'src/ink-canvas/types';
+
+const stroke: InkStroke = {
+	id: 'cached-stroke',
+	points: [[0, 0, 0.5], [20, 10, 0.6], [40, 5, 0.5]],
+	style: { ...DEFAULT_STROKE_STYLE },
+	offset: { x: 0, y: 0 },
+};
+
+describe('rendered stroke cache', () => {
+	test('reuses the rendered outline for the same immutable stroke', () => {
+		const first = getRenderedStrokeData(stroke);
+		const second = getRenderedStrokeData(stroke);
+
+		expect(second).toBe(first);
+		expect(first.pathD).not.toBe('');
+		expect(first.bounds.maxX).toBeGreaterThan(first.bounds.minX);
+	});
+
+	test('keeps translation outside cached path geometry', () => {
+		const movedStroke = { ...stroke, offset: { x: 100, y: 200 } };
+		const original = getRenderedStrokeData(stroke);
+		const moved = getRenderedStrokeData(movedStroke);
+
+		expect(moved.pathD).toBe(original.pathD);
+		expect(moved.bounds).toEqual(original.bounds);
+	});
+});

--- a/tests/ink-canvas/stroke-store.test.ts
+++ b/tests/ink-canvas/stroke-store.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from '@jest/globals';
+import { StrokeStore, type StrokeStoreChange } from 'src/ink-canvas/stroke-store';
+import type { InkStroke } from 'src/ink-canvas/types';
+import { DEFAULT_STROKE_STYLE } from 'src/ink-canvas/types';
+
+function makeStroke(id: string): InkStroke {
+	return {
+		id,
+		points: [[0, 0, 0.5], [10, 10, 0.5]],
+		style: { ...DEFAULT_STROKE_STYLE },
+		offset: { x: 0, y: 0 },
+	};
+}
+
+describe('StrokeStore change notifications', () => {
+	test('identifies only the strokes touched by incremental mutations', () => {
+		const store = new StrokeStore();
+		const changes: StrokeStoreChange[] = [];
+		store.subscribe((change) => changes.push(change));
+
+		store.add(makeStroke('a'));
+		store.addMany([makeStroke('b'), makeStroke('c')]);
+		store.updateOffsets(new Map([['b', { x: 5, y: 8 }]]));
+		store.remove(['a']);
+
+		expect(changes).toEqual([
+			{ type: 'add', ids: ['a'] },
+			{ type: 'addMany', ids: ['b', 'c'] },
+			{ type: 'updateOffsets', ids: ['b'] },
+			{ type: 'remove', ids: ['a'] },
+		]);
+	});
+
+	test('marks whole-store replacement mutations explicitly', () => {
+		const store = new StrokeStore();
+		const changes: StrokeStoreChange[] = [];
+		store.subscribe((change) => changes.push(change));
+
+		store.replaceAll([makeStroke('a')]);
+		store.clear();
+
+		expect(changes).toEqual([
+			{ type: 'replaceAll', ids: [] },
+			{ type: 'clear', ids: [] },
+		]);
+	});
+});


### PR DESCRIPTION
## Why

I genuinely love Ink and use it every day for handwritten notes across my PC and iPad. Because it is such an important part of my daily workflow, I wanted to improve a performance problem I was consistently reaching in long writing attachments rather than work around it by splitting up my notes.

After writing on one attachment for a long time, pen input became progressively laggy. The same synced note lagged sooner on an 8th-generation iPad than on PC. This is related to #84: v0.5 improved the earlier general lag substantially, but very large ink-canvas attachments could still hitch as they kept growing.

The real-world writing used to reproduce this reached 1,193 strokes, 23,457 input points, and a 3.65 MB SVG. The sample contains personal course notes, so it is not included in the repository.

## Root cause

Several pieces of work scaled with the entire attachment and could land directly on the input thread:

- every autosave regenerated all perfect-freehand outlines twice, once for bounds and again for SVG paths;
- the save pipeline DOM-parsed and pretty-printed the complete multi-megabyte SVG just to replace metadata;
- every stroke invalidated all path and bounds caches and repeatedly rescanned the full document for writing height;
- two equivalent saves were scheduled after each change; and
- an autosave timer could fire after the next Apple Pencil stroke had already started, producing the remaining occasional iPad hitch.

## What changed

- Cache immutable rendered stroke paths and local bounds in a `WeakMap`, shared by the live editor and SVG export without retaining deleted strokes.
- Generate each stroke's path and bounds together during export instead of running perfect-freehand twice.
- Add mutation-aware `StrokeStore` events so only touched cache entries are invalidated; offset-only moves retain their path data.
- Track the writing content bottom incrementally for normal added strokes and avoid redundant full-document height scans.
- Replace only the small `<metadata>` block during ink-canvas saves, preserving rendered SVG markup and using compact, XML-safe JSON instead of DOM parsing and whole-file pretty-printing.
- Remove the redundant second autosave.
- Prevent autosaves from running during active pen/pointer interaction and use a two-second mobile quiet period while retaining the shorter desktop delay.
- Add regression coverage for metadata round trips, cached stroke geometry, store mutation events, and mobile autosave delay selection.

## Measurements

Using the earlier 824-stroke / 16,108-point version of the same real-world writing attachment in a local Node benchmark:

| Save work | Before | After |
| --- | ---: | ---: |
| Stroke rendering | 113.21 ms | 22.03 ms |
| File serialization | 540.89 ms | 13.09 ms |
| Total steady save processing | ~654 ms | ~35 ms |
| Generated SVG size | 3,463,900 bytes | 2,488,112 bytes |

That is approximately a 94.6% reduction in steady save processing and a 28.2% reduction in generated file size in this benchmark. The second pass additionally ensures that the remaining save work never begins in the middle of an active Pencil stroke.

## Validation

- Manually tested with the same synced note on PC and an 8th-generation iPad; writing is now smooth in the previously lagging attachment.
- `npm run test:unit -- --runInBand` — 60 suites and 577 tests passed.
- `npm run build` — TypeScript and production esbuild completed successfully.
- Verified ink-canvas serialization round-trips the complete snapshot without changing stroke data.

Related to #84.
