### PR TITLE
feature: Add Stroke Style UI

### DIFF
--- a/src/components/formats/current/drawing/drawing-editor/drawing-editor.tsx
+++ b/src/components/formats/current/drawing/drawing-editor/drawing-editor.tsx
@@ -42,6 +42,7 @@ import { buildInkStrokeStyleForTreatAs } from 'src/ink-canvas/stroke-presets';
 import { inkStrokeTimestampsFromBooxPoints } from 'src/ink-canvas/utils/stroke-timestamps';
 import { isWritingAlignedDrawingEmbed, type EmbedSettings } from 'src/types/embed-settings';
 import { showLegacyInkUnlockNotice } from 'src/logic/utils/legacy-ink-notice';
+import { StyleMenu } from 'src/components/jsx-components/style-menu/style-menu';
 
 ///////////////////////////
 ///////////////////////////
@@ -809,6 +810,10 @@ export function DrawingEditor(props: DrawingEditorProps) {
 					embedId={props.embedded && props.embedId ? props.embedId : undefined}
 					workspaceLeafId={props.embedded && props.workspaceLeafId ? props.workspaceLeafId : undefined}
 					plugin={props.embedded ? getGlobals().plugin : undefined}
+				/>
+				<StyleMenu
+					getEditor={getEditor}
+					onStoreChange={handleStoreChange}
 				/>
 			</SecondaryMenuBar>
 

--- a/src/components/formats/current/writing/writing-editor/writing-editor.tsx
+++ b/src/components/formats/current/writing/writing-editor/writing-editor.tsx
@@ -56,6 +56,7 @@ import type { InkCanvasEditor, InkCanvasSnapshot, InkStroke, InkPoint } from 'sr
 import { normalizeBooxPenPressureForCapture } from 'src/ink-canvas/constants/pen-input';
 import { buildInkStrokeStyleForTreatAs } from 'src/ink-canvas/stroke-presets';
 import { inkStrokeTimestampsFromBooxPoints } from 'src/ink-canvas/utils/stroke-timestamps';
+import { StyleMenu } from 'src/components/jsx-components/style-menu/style-menu';
 
 ///////////////////////////
 ///////////////////////////
@@ -1028,6 +1029,10 @@ export function WritingEditor(props: WritingEditorProps) {
 				{props.embedded && booxConnected && (
 					<ExpandLinesButton onExpandLines={expandWritingLinesByOne} />
 				)}
+				<StyleMenu
+					getEditor={getEditor}
+					onStoreChange={handleStoreChange}
+				/>
 			</SecondaryMenuBar>
 		</div>
 	</>;

--- a/src/components/jsx-components/style-menu/style-menu.scss
+++ b/src/components/jsx-components/style-menu/style-menu.scss
@@ -6,19 +6,6 @@
     right: 24px;        
     z-index: 1000;   
 
-    transition: opacity 0.2s ease, transform 0.2s ease;
-    
-    &.ink_hidden {
-        opacity: 0;
-        pointer-events: none;
-    }
-    
-    &.ink_visible {
-        opacity: 1;
-        pointer-events: auto;
-    }
-
-
     button {
         width: 2.5em;
         height: 2.5em;

--- a/src/components/jsx-components/style-menu/style-menu.scss
+++ b/src/components/jsx-components/style-menu/style-menu.scss
@@ -1,0 +1,137 @@
+.ink_style-menu {
+    display: flex;
+    gap: 8px;
+    position: fixed; 
+    bottom: 48px;       
+    right: 24px;        
+    z-index: 1000;   
+
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    
+    &.ink_hidden {
+        opacity: 0;
+        pointer-events: none;
+    }
+    
+    &.ink_visible {
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+
+    button {
+        width: 2.5em;
+        height: 2.5em;
+        border-radius: 0.8em;
+        padding: 0 !important;
+        cursor: pointer;
+    }
+}
+
+.ink_style-menu-item {
+    position: relative;
+}
+
+.ink_color-button, 
+.ink_size-button,
+.ink_dash-button {      
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.ink_color-indicator {
+    width: 1.5em;
+    height: 1.5em;
+    border-radius: 50%;
+    border: 2px solid var(--background-modifier-border);
+}
+
+.ink_size-indicator,
+.ink_dash-indicator {
+    width: 1.5em;
+    height: 1.5em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.ink_size-line {
+    width: 80%;
+    background-color: var(--text-normal);
+    border-radius: 0.3em;
+}
+
+.ink_style-picker {
+    position: absolute;
+    bottom: 3em;
+    left: 100%;
+    transform: translateX(-100%);
+
+    display: grid;
+    /* REMOVED: grid-template-columns: repeat(5, 1fr); */
+    gap: 6px;
+    padding: 8px;
+
+    background-color: var(--background-primary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 8px;
+    box-shadow: var(--shadow-s);
+
+    z-index: 1000;
+    pointer-events: auto;
+}
+
+.ink_color-picker,
+.ink_size-picker {
+    grid-template-columns: repeat(5, 1fr);
+}
+
+.ink_dash-picker {
+    grid-template-columns: repeat(3, 1fr);
+}
+
+.ink_color-option {
+    width: 2em;
+    height: 2em;
+    border-radius: 50%;
+    border: 2px solid var(--background-modifier-border);
+    cursor: pointer;
+    transition: transform 0.1s ease;
+
+    &:hover {
+        transform: scale(1.1);
+    }
+
+    &.ink_active {
+        border: 3px solid var(--interactive-accent);
+        box-shadow: 0 0 0 2px var(--background-primary);
+    }
+}
+
+.ink_size-option,
+.ink_dash-option {
+    width: 2em;
+    height: 2em;
+    border-radius: 0.4em;
+    border: 2px solid var(--background-modifier-border);
+    cursor: pointer;
+    transition: transform 0.1s ease;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px;
+
+    background-color: var(--background-primary);
+
+    &:hover {
+        transform: scale(1.1);
+        background-color: var(--background-modifier-hover);
+    }
+
+    &.ink_active {
+        border: 3px solid var(--interactive-accent);
+        background-color: var(--background-modifier-hover);
+    }
+}

--- a/src/components/jsx-components/style-menu/style-menu.tsx
+++ b/src/components/jsx-components/style-menu/style-menu.tsx
@@ -1,0 +1,245 @@
+import "./style-menu.scss";
+import { InkCanvasEditor } from 'src/ink-canvas/types';
+import * as React from 'react';
+import classNames from 'classnames';
+import { TooltipButton } from 'src/components/jsx-components/tooltip-button/tooltip-button';
+import { getEditor } from "src/logic/undo-redo/ink-editor-registry";
+
+
+export const STROKE_COLORS = [
+    // Neutrals
+    { name: 'White', value: '#FFFFFF', darkColor: '#f3f3f3' },
+    { name: 'Gray', value: '#9fa8b2', darkColor: '#9398b0' },
+    { name: 'Black', value: '#1d1d1d', darkColor: '#1d1d1d' },
+
+    // Reds
+    { name: 'Red', value: '#e03131', darkColor: '#e03131' },
+    { name: 'Light Red', value: '#f87777', darkColor: '#ff8787' },
+
+    // Orange & Yellow
+    { name: 'Orange', value: '#e16919', darkColor: '#f76707' },
+    { name: 'Yellow', value: '#f1ac4b', darkColor: '#ffc034' },
+
+    // Greens
+    { name: 'Green', value: '#099268', darkColor: '#099268' },
+    { name: 'Light Green', value: '#4cb05e', darkColor: '#40c057' },
+
+    // Blues
+    { name: 'Blue', value: '#4465e9', darkColor: '#4f72fc' },
+    { name: 'Light Blue', value: '#4ba1f1', darkColor: '#4dabf7' },
+
+    // Violets
+    { name: 'Violet', value: '#ae3ec9', darkColor: '#ae3ec9' },
+    { name: 'Light Violet', value: '#e085f4', darkColor: '#e599f7' },
+];
+
+export const STROKE_SIZES = [
+	{ name: 'XS', size: 2 },
+	{ name: 'S', size: 4 },
+	{ name: 'M', size: 6 },
+	{ name: 'L', size: 8 },
+	{ name: 'XL', size: 10 },
+	{ name: '2XL', size: 12 },
+	{ name: '3XL', size: 14 },
+	{ name: '4XL', size: 16 },
+	{ name: '5XL', size: 18 },
+	{ name: '6XL', size: 20 },
+];
+
+// Define Dash options
+export const STROKE_DASHES = [
+    { name: 'Solid', value: 'solid', preview: '—' },
+    { name: 'Dashed', value: 'dashed', preview: '- -' },
+    { name: 'Dotted', value: 'dotted' , preview: '•••'},
+];
+
+interface StyleMenuProps {
+    getEditor: () => InkCanvasEditor | undefined;
+    onStoreChange: () => void;
+}
+
+
+export const StyleMenu = React.forwardRef<HTMLDivElement, StyleMenuProps>((props, ref) => {
+
+    const [showColorPicker, setShowColorPicker] = React.useState<boolean>(false);
+    const [showSizePicker, setShowSizePicker] = React.useState<boolean>(false);
+    const [showDashPicker, setShowDashPicker] = React.useState<boolean>(false);
+    const [isDrawTool, setisDrawTool] = React.useState<boolean>(true);
+
+    const [currentColor, setCurrentColor] = React.useState<string>(STROKE_COLORS[0].value);
+    const [currentSize, setCurrentSize] = React.useState<number>(STROKE_SIZES[3].size);
+    const [currentDash, setCurrentDash] = React.useState<string>(STROKE_DASHES[0].value);
+
+
+    React.useEffect(() => {
+        const editor = props.getEditor();
+        if (!editor) return;
+
+        setisDrawTool(editor.getCurrentTool() === "draw");
+
+        const unsubscribe = editor.subscribeToolChange((inkTool) => {
+            setisDrawTool(inkTool === "draw");
+        });
+
+        return () => {
+            if (typeof unsubscribe === 'function') {
+                unsubscribe();
+            } 
+        };
+    }, [props]);
+
+    function selectColor(color: string) {
+        const editor = props.getEditor();
+		if (!editor) return;
+
+        editor.setStrokeStyle({color: color});
+
+		setCurrentColor(color);
+		setShowColorPicker(false);
+	}
+
+    function selectSize(size: number) {
+        const editor = props.getEditor();
+		if (!editor) return;
+
+        editor.setStrokeStyle({size: size});
+
+		setCurrentSize(size);
+		setShowSizePicker(false);
+	}
+
+    function selectDash(dash: any) {
+        const editor = props.getEditor();
+		if (!editor) return;
+
+        editor.setStrokeStyle({dash: dash});
+
+		setCurrentDash(dash);
+		setShowDashPicker(false);
+	}
+
+    return <>
+        <div
+            ref = {ref}
+            className = {classNames([
+                'ink_menu-bar',
+                'ink_menu-bar_floating'
+            ])}
+        >
+            <div className={classNames([
+                'ink_style-menu',
+                isDrawTool ? 'ink_visible' : 'ink_hidden'
+                ])}
+            >
+				{/* Color picker button */}
+		    	<div className='ink_style-menu-item'>
+		    		<TooltipButton
+		    			tooltip='Color-Picker'
+                        className='ink_size-button'
+		    		    onClick={() => {
+                            setShowSizePicker(false);
+                            setShowDashPicker(false);
+                            setShowColorPicker(!showColorPicker);
+                        }}
+    				>
+    					<div
+    						className='ink_color-indicator'
+    						style={{ backgroundColor: currentColor }}
+    					/>
+					</TooltipButton>
+                    {showColorPicker && (
+						<div className='ink_style-picker ink_color-picker'>
+							{STROKE_COLORS.map((color) => (
+								<TooltipButton
+									key={color.name}
+									className={classNames([
+										'ink_color-option',
+                                        currentColor === color.value && 'ink_active'
+									])}
+									style={{ backgroundColor: color.value }}
+									onClick={() => selectColor(color.value)}
+									tooltip={color.name}
+								/>
+							))}
+						</div>
+					)}
+				</div>
+                    
+                {/* Stroke size picker button */}
+				<div className='ink_style-menu-item'>
+					<TooltipButton
+						tooltip='Stroke-Size'
+					    onClick={() => {
+                            setShowColorPicker(false);
+                            setShowDashPicker(false);
+                            setShowSizePicker(!showSizePicker);
+                        }}
+                        className='ink_size-button'
+					>
+						<div className='ink_size-indicator'>
+							<div
+								className='ink_size-line'
+								style={{ height: `${currentSize * 0.05}em` }}
+							/>
+						</div>
+					</TooltipButton>
+                    {showSizePicker && (
+						<div className='ink_style-picker ink_size-picker'>
+							{STROKE_SIZES.map((size) => (
+								<TooltipButton
+									key={size.size}
+									className={classNames([
+										'ink_size-option',
+										currentSize === size.size && 'ink_active'
+									])}
+									onClick={() => selectSize(size.size)}
+									tooltip={`${size.name} - ${size.size}`}
+								>
+									<div
+										className='ink_size-line'
+										style={{ height: `${size.size * 0.05}em` }}
+									/>
+								</TooltipButton>
+							))}
+						</div>
+					)}
+				</div>
+                {/* Dash style picker button */}
+				<div className='ink_style-menu-item'>
+					<TooltipButton
+						tooltip='Line-Style'
+					    onClick={() => {
+                            setShowColorPicker(false);
+                            setShowSizePicker(false);
+                            setShowDashPicker(!showDashPicker);
+                           }}
+                           className='ink_dash-button'
+					>
+				        <div className='ink_dash-indicator'>
+							{currentDash === 'solid' ? '—' : currentDash === 'dashed' ? '- -' : '•••'}
+						</div>
+					</TooltipButton>
+                    {showDashPicker && (
+						<div className='ink_style-picker ink_dash-picker'>
+							{STROKE_DASHES.map((dash) => (
+								<TooltipButton
+									key={dash.value}
+									className={classNames([
+										'ink_dash-option',
+										currentDash === dash.value && 'ink_active'
+									])}
+									onClick={() => selectDash(dash.value)}
+									tooltip={dash.name}
+								>
+									<div className='ink_dash-indicator'>
+										{dash.preview}
+									</div>
+								</TooltipButton>
+							))}
+						</div>
+					)}
+				</div>
+			</div>
+        </div>
+    </>;
+});

--- a/src/components/jsx-components/style-menu/style-menu.tsx
+++ b/src/components/jsx-components/style-menu/style-menu.tsx
@@ -3,7 +3,6 @@ import { InkCanvasEditor } from 'src/ink-canvas/types';
 import * as React from 'react';
 import classNames from 'classnames';
 import { TooltipButton } from 'src/components/jsx-components/tooltip-button/tooltip-button';
-import { getEditor } from "src/logic/undo-redo/ink-editor-registry";
 
 
 export const STROKE_COLORS = [
@@ -64,29 +63,10 @@ export const StyleMenu = React.forwardRef<HTMLDivElement, StyleMenuProps>((props
     const [showColorPicker, setShowColorPicker] = React.useState<boolean>(false);
     const [showSizePicker, setShowSizePicker] = React.useState<boolean>(false);
     const [showDashPicker, setShowDashPicker] = React.useState<boolean>(false);
-    const [isDrawTool, setisDrawTool] = React.useState<boolean>(true);
 
     const [currentColor, setCurrentColor] = React.useState<string>(STROKE_COLORS[0].value);
     const [currentSize, setCurrentSize] = React.useState<number>(STROKE_SIZES[3].size);
     const [currentDash, setCurrentDash] = React.useState<string>(STROKE_DASHES[0].value);
-
-
-    React.useEffect(() => {
-        const editor = props.getEditor();
-        if (!editor) return;
-
-        setisDrawTool(editor.getCurrentTool() === "draw");
-
-        const unsubscribe = editor.subscribeToolChange((inkTool) => {
-            setisDrawTool(inkTool === "draw");
-        });
-
-        return () => {
-            if (typeof unsubscribe === 'function') {
-                unsubscribe();
-            } 
-        };
-    }, [props]);
 
     function selectColor(color: string) {
         const editor = props.getEditor();
@@ -126,11 +106,7 @@ export const StyleMenu = React.forwardRef<HTMLDivElement, StyleMenuProps>((props
                 'ink_menu-bar_floating'
             ])}
         >
-            <div className={classNames([
-                'ink_style-menu',
-                isDrawTool ? 'ink_visible' : 'ink_hidden'
-                ])}
-            >
+            <div className='ink_style-menu'>
 				{/* Color picker button */}
 		    	<div className='ink_style-menu-item'>
 		    		<TooltipButton

--- a/src/components/jsx-components/tooltip-button/tooltip-button.tsx
+++ b/src/components/jsx-components/tooltip-button/tooltip-button.tsx
@@ -11,7 +11,8 @@ interface TooltipButtonProps {
 	onPointerDown?: (e: React.PointerEvent<HTMLButtonElement>) => void;
 	disabled?: boolean;
 	className?: string;
-	children: React.ReactNode;
+	children?: React.ReactNode;
+	style?: React.CSSProperties;
 }
 
 /**
@@ -28,6 +29,7 @@ export const TooltipButton: React.FC<TooltipButtonProps> = ({
 	disabled,
 	className,
 	children,
+	style
 }) => {
 	const [tooltipVisible, setTooltipVisible] = React.useState(false);
 	const holdTimerRef = React.useRef<number | null>(null);
@@ -72,6 +74,7 @@ export const TooltipButton: React.FC<TooltipButtonProps> = ({
 				onPointerLeave={dismissTooltip}
 				onPointerCancel={dismissTooltip}
 				onClick={onClick}
+				style={style}
 			>
 				{children}
 			</button>

--- a/src/ink-canvas/commands.ts
+++ b/src/ink-canvas/commands.ts
@@ -137,12 +137,22 @@ export class UpdateStrokesStyleCommand implements InkCommand {
     }
 
     apply(): void {
-        for (const id of this.strokeIds) {
-            const stroke = this.store.getById(id);
-            if (stroke) {
-                stroke.style = { ...stroke.style, ...this.newStylePartial };
+
+		const strokes = this.store.getAll();
+        
+        // Create a brand new array with brand new stroke references for affected IDs
+        const updatedStrokes = strokes.map(stroke => {
+            if (this.strokeIds.includes(stroke.id)) {
+                return {
+                    ...stroke,
+                    style: { ...stroke.style, ...this.newStylePartial }
+                };
             }
-        }
+            return stroke;
+        });
+
+        // Push the new array back into the store
+        this.store.replaceAll(updatedStrokes);
         this.store.notify();
     }
 

--- a/src/ink-canvas/commands.ts
+++ b/src/ink-canvas/commands.ts
@@ -1,5 +1,5 @@
 import type { StrokeStore } from './stroke-store';
-import type { InkStroke } from './types';
+import type { InkStroke, InkStrokeStyle } from './types';
 
 ///////////////////////////
 ///////////////////////////
@@ -108,4 +108,52 @@ export class EraseAllCommand implements InkCommand {
 	unapply(): void {
 		this.store.replaceAll(this.previousStrokes);
 	}
+}
+
+/** Update the style of one or more strokes. */
+export class UpdateStrokesStyleCommand implements InkCommand {
+    private store: StrokeStore;
+    private strokeIds: string[];
+    private newStylePartial: Partial<InkStrokeStyle>;
+    private previousStyles: Map<string, InkStrokeStyle>;
+
+    constructor(
+        store: StrokeStore,
+        strokeIds: string[],
+        newStylePartial: Partial<InkStrokeStyle>
+    ) {
+        this.store = store;
+        this.strokeIds = strokeIds;
+        this.newStylePartial = newStylePartial;
+        this.previousStyles = new Map();
+
+        for (const id of strokeIds) {
+            const stroke = store.getById(id);
+            if (stroke) {
+                // Clone the previous style object so undo restores exact values
+                this.previousStyles.set(id, { ...stroke.style });
+            }
+        }
+    }
+
+    apply(): void {
+        for (const id of this.strokeIds) {
+            const stroke = this.store.getById(id);
+            if (stroke) {
+                stroke.style = { ...stroke.style, ...this.newStylePartial };
+            }
+        }
+        this.store.notify();
+    }
+
+    unapply(): void {
+        for (const id of this.strokeIds) {
+            const prevStyle = this.previousStyles.get(id);
+            const stroke = this.store.getById(id);
+            if (stroke && prevStyle) {
+                stroke.style = { ...prevStyle };
+            }
+        }
+        this.store.notify();
+    }
 }

--- a/src/ink-canvas/ink-svg-canvas.tsx
+++ b/src/ink-canvas/ink-svg-canvas.tsx
@@ -1289,17 +1289,24 @@ interface StrokePathProps {
 }
 
 function strokePathPropsAreEqual(prev: StrokePathProps, next: StrokePathProps): boolean {
-	if (prev.isSelected !== next.isSelected) return false;
-	if (prev.pathDCache !== next.pathDCache) return false;
-	const a = prev.stroke;
-	const b = next.stroke;
-	if (a === b) return true;
-	if (a.id !== b.id) return false;
-	if (a.points !== b.points) return false;
-	if (a.style !== b.style) return false;
-	// Offset-only changes still need a re-render for the translate transform, but not a new `d`.
-	if (a.offset.x !== b.offset.x || a.offset.y !== b.offset.y) return false;
-	return true;
+    if (prev.isSelected !== next.isSelected) return false;
+    if (prev.pathDCache !== next.pathDCache) return false;
+    const a = prev.stroke;
+    const b = next.stroke;
+    if (a === b) return true;
+    if (a.id !== b.id) return false;
+    if (a.points !== b.points) return false;
+    
+    // Check individual style properties instead of a strict `a.style !== b.style` reference check.
+    // If your editor mutates the style object in place, `a.style === b.style` would evaluate to true 
+    // and skip re-rendering even if the color or size changed!
+    if (a.style.color !== b.style.color) return false;
+    if (a.style.size !== b.style.size) return false;
+    if (a.style.dash !== b.style.dash) return false;
+
+    // Offset-only changes still need a re-render for the translate transform, but not a new `d`.
+    if (a.offset.x !== b.offset.x || a.offset.y !== b.offset.y) return false;
+    return true;
 }
 
 const StrokePath = memo(function StrokePath(props: StrokePathProps): React.JSX.Element {
@@ -1307,8 +1314,11 @@ const StrokePath = memo(function StrokePath(props: StrokePathProps): React.JSX.E
     
     const isDashedOrDotted = stroke.style.dash && stroke.style.dash !== 'solid';
 
+	//Create unique cache key
+	const geometryCacheKey = `${stroke.id}-${stroke.style.size}-${stroke.style.dash}`;
+
     // Build the SVG path data depending on the dash style
-    let d = pathDCache.get(stroke.id);
+    let d = pathDCache.get(geometryCacheKey);
     if (d === undefined) {
         if (isDashedOrDotted) {
             // Render a single spine for dashed/dotted lines
@@ -1318,7 +1328,7 @@ const StrokePath = memo(function StrokePath(props: StrokePathProps): React.JSX.E
             const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
             d = getSvgPathFromStroke(outlinePoints);
         }
-        pathDCache.set(stroke.id, d);
+        pathDCache.set(geometryCacheKey, d);
     }
 
     const hasOffset = stroke.offset.x !== 0 || stroke.offset.y !== 0;
@@ -1375,7 +1385,6 @@ export function getDashArray(dash?: StrokeDashStyle, size = 8): string | undefin
 export function getCenterLinePath(points: any[]): string {
     if (!points || points.length === 0) return '';
     
-    // perfect-freehand points can be arrays [x, y] or objects {x, y}
     const getPt = (p: any) => (Array.isArray(p) ? { x: p[0], y: p[1] } : { x: p.x, y: p.y });
     
     const start = getPt(points[0]);

--- a/src/ink-canvas/ink-svg-canvas.tsx
+++ b/src/ink-canvas/ink-svg-canvas.tsx
@@ -16,7 +16,7 @@ import {
 } from './stroke-viewport-culling';
 import { cropWritingStrokeHeightInvitingly } from 'src/components/formats/current/utils/tldraw-helpers';
 import { WRITING_LINE_HEIGHT, WRITING_PAGE_WIDTH } from 'src/constants';
-import { AddStrokeCommand, EraseAllCommand, RemoveStrokesCommand } from './commands';
+import { AddStrokeCommand, EraseAllCommand, RemoveStrokesCommand, UpdateStrokesStyleCommand } from './commands';
 import { drawToolPointerDown, drawToolPointerMove, drawToolPointerUp, drawToolPointerCancel } from './tools/draw-tool';
 import { eraseToolPointerDown, eraseToolPointerMove, eraseToolPointerUp, eraseToolPointerCancel } from './tools/erase-tool';
 import { selectToolPointerDown, selectToolPointerMove, selectToolPointerUp, selectToolPointerCancel } from './tools/select-tool';
@@ -29,7 +29,7 @@ import { useResolvedStrokeInputTreatAs } from 'src/logic/device-settings/use-res
 import { useBooxConnectionEnabled } from 'src/logic/device-settings/use-boox-connection-enabled';
 import { DEFAULT_SETTINGS } from 'src/types/plugin-settings';
 import { toStrokeOptions, DEFAULT_STROKE_STYLE } from './types';
-import type { InkTool, InkStrokeStyle, CameraState, InkCanvasSnapshot, InkCanvasEditor, InkStroke } from './types';
+import type { InkTool, InkStrokeStyle, CameraState, InkCanvasSnapshot, InkCanvasEditor, InkStroke, StrokeDashStyle } from './types';
 import type { DrawToolContext } from './tools/draw-tool';
 import type { EraseToolContext } from './tools/erase-tool';
 import type { SelectToolContext } from './tools/select-tool';
@@ -483,7 +483,14 @@ export function InkSvgCanvas(props: InkSvgCanvasProps): React.JSX.Element {
 
 			getStrokeStyle: () => ({ ...strokeStyleRef.current }),
 			setStrokeStyle: (partial: Partial<InkStrokeStyle>) => {
-				setStrokeStyle(prev => ({ ...prev, ...partial }));
+    			setStrokeStyle(prev => ({ ...prev, ...partial }));
+
+    			const selectedIds = selectedIdsRef.current;
+    			if (selectedIds.size > 0) {
+        			const ids = Array.from(selectedIds);
+        			const cmd = new UpdateStrokesStyleCommand(storeRef.current, ids, partial);
+        			undoManagerRef.current.execute(cmd);
+    			}
 			},
 
 			getCamera: () => ({ ...cameraRef.current }),
@@ -1296,42 +1303,88 @@ function strokePathPropsAreEqual(prev: StrokePathProps, next: StrokePathProps): 
 }
 
 const StrokePath = memo(function StrokePath(props: StrokePathProps): React.JSX.Element {
-	const { stroke, isSelected, pathDCache } = props;
-	// All strokes render through perfect-freehand's `getStroke` directly — the same call the
-	// live preview makes (see `draw-tool.ts`), so committed strokes match what was drawn.
-	// Cached by stroke id: parent re-renders (viewportRevision, unrelated store updates after
-	// cache clear + remount) reuse `d` when the id is still populated; offset is transform-only.
-	let d = pathDCache.get(stroke.id);
-	if (d === undefined) {
-		const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
-		d = getSvgPathFromStroke(outlinePoints);
-		pathDCache.set(stroke.id, d);
-	}
+    const { stroke, isSelected, pathDCache } = props;
+    
+    const isDashedOrDotted = stroke.style.dash && stroke.style.dash !== 'solid';
 
-	const hasOffset = stroke.offset.x !== 0 || stroke.offset.y !== 0;
+    // Build the SVG path data depending on the dash style
+    let d = pathDCache.get(stroke.id);
+    if (d === undefined) {
+        if (isDashedOrDotted) {
+            // Render a single spine for dashed/dotted lines
+            d = getCenterLinePath(stroke.points);
+        } else {
+            // Render the pressure-sensitive outline for solid lines
+            const outlinePoints = getStroke(stroke.points, toStrokeOptions(stroke.style));
+            d = getSvgPathFromStroke(outlinePoints);
+        }
+        pathDCache.set(stroke.id, d);
+    }
 
-	return (
-		<g
-			data-stroke-group=""
-			data-stroke-id={stroke.id}
-			data-offset-x={stroke.offset.x}
-			data-offset-y={stroke.offset.y}
-			transform={hasOffset ? `translate(${stroke.offset.x}, ${stroke.offset.y})` : undefined}
-		>
-			<path
-				data-stroke-id={stroke.id}
-				d={d}
-				fill={stroke.style.color}
-			/>
-			{isSelected && (
-				<path
-					d={d}
-					fill="none"
-					stroke="rgba(0, 123, 255, 0.6)"
-					strokeWidth={2}
-					pointerEvents="none"
-				/>
-			)}
-		</g>
-	);
+    const hasOffset = stroke.offset.x !== 0 || stroke.offset.y !== 0;
+
+    return (
+        <g
+            data-stroke-group=""
+            data-stroke-id={stroke.id}
+            data-offset-x={stroke.offset.x}
+            data-offset-y={stroke.offset.y}
+            transform={hasOffset ? `translate(${stroke.offset.x}, ${stroke.offset.y})` : undefined}
+        >
+            <path
+                data-stroke-id={stroke.id}
+                d={d}
+                // Switch between filled polygons (solid) and stroked lines (dashed)
+                fill={isDashedOrDotted ? 'none' : stroke.style.color}
+                stroke={isDashedOrDotted ? stroke.style.color : undefined}
+                strokeWidth={isDashedOrDotted ? stroke.style.size : undefined}
+                strokeDasharray={isDashedOrDotted ? getDashArray(stroke.style.dash, stroke.style.size) : undefined}
+                strokeLinecap={isDashedOrDotted ? 'round' : undefined}
+                strokeLinejoin={isDashedOrDotted ? 'round' : undefined}
+            />
+            {isSelected && (
+                <path
+                    d={d}
+                    fill="none"
+                    stroke="rgba(0, 123, 255, 0.6)"
+                    strokeWidth={2}
+                    pointerEvents="none"
+                />
+            )}
+        </g>
+    );
 }, strokePathPropsAreEqual);
+
+
+/** Helper function to convert dash style into SVG stroke-dasharray values */
+export function getDashArray(dash?: StrokeDashStyle, size = 8): string | undefined {
+    if (dash === 'dashed') {
+        const dashLen = size * 2.5;
+        const gapLen = size * 1.5;
+        return `${dashLen},${gapLen}`;
+    }
+    if (dash === 'dotted') {
+        const dotLen = size * 0;
+        const gapLen = size * 2;
+        return `${dotLen},${gapLen}`;
+    }
+    return undefined;
+}
+
+/** Helper function to draw a standard line through the raw input points*/
+export function getCenterLinePath(points: any[]): string {
+    if (!points || points.length === 0) return '';
+    
+    // perfect-freehand points can be arrays [x, y] or objects {x, y}
+    const getPt = (p: any) => (Array.isArray(p) ? { x: p[0], y: p[1] } : { x: p.x, y: p.y });
+    
+    const start = getPt(points[0]);
+    let d = `M ${start.x} ${start.y}`;
+    
+    for (let i = 1; i < points.length; i++) {
+        const pt = getPt(points[i]);
+        d += ` L ${pt.x} ${pt.y}`;
+    }
+    
+    return d;
+}

--- a/src/ink-canvas/stroke-store.ts
+++ b/src/ink-canvas/stroke-store.ts
@@ -20,7 +20,7 @@ export class StrokeStore {
 		return () => { this.listeners.delete(listener); };
 	}
 
-	private notify(): void {
+	notify(): void {
 		for (const listener of this.listeners) {
 			listener();
 		}

--- a/src/ink-canvas/tools/draw-tool.ts
+++ b/src/ink-canvas/tools/draw-tool.ts
@@ -16,6 +16,7 @@ import {
 	PEN_PRESSURE_SLEW_PER_SIZE,
 	PEN_PRESSURE_SMOOTHING_ALPHA,
 } from '../constants/pen-input';
+import { getDashArray } from '../ink-svg-canvas';
 ///////////////////////////
 ///////////////////////////
 
@@ -556,17 +557,57 @@ function setOrAppendLastPoint(stroke: ActiveStroke, next: InkPoint): void {
 
 /** Imperatively update the live stroke <path> element (no React re-render). */
 function updateLiveStrokePath(ctx: DrawToolContext): void {
-	if (!activeStroke) return;
-	const livePath = ctx.getLiveStrokePath();
-	if (!livePath) return;
+    if (!activeStroke) return;
+    const livePath = ctx.getLiveStrokePath();
+    if (!livePath) return;
 
-	// WYSIWYG: render the live preview from the SAME `points` array, the SAME function
-	// (`getStroke`), and the SAME options (`toStrokeOptions`) that `ink-svg-canvas` / export
-	// use when the stroke commits — so the in-progress trail and the stored stroke are
-	// byte-identical. The last point is replaced in place while within merge radius of the tip,
-	// so the live stroke tracks the pen without chord lag.
-	const outlinePoints = getStroke(activeStroke.points, toStrokeOptions(activeStroke.style));
-	const pathData = getSvgPathFromStroke(outlinePoints);
-	livePath.setAttribute('d', pathData);
-	livePath.setAttribute('fill', activeStroke.style.color);
+    const style = activeStroke.style;
+    const isDashedOrDotted = style.dash && style.dash !== 'solid';
+
+    let pathData = '';
+    if (isDashedOrDotted) {
+        pathData = getCenterLinePath(activeStroke.points);
+    } else {
+		// WYSIWYG: render the live preview from the SAME `points` array, the SAME function
+		// (`getStroke`), and the SAME options (`toStrokeOptions`) that `ink-svg-canvas` / export
+		// use when the stroke commits — so the in-progress trail and the stored stroke are
+		// byte-identical. The last point is replaced in place while within merge radius of the tip,
+		// so the live stroke tracks the pen without chord lag.
+        const outlinePoints = getStroke(activeStroke.points, toStrokeOptions(style));
+        pathData = getSvgPathFromStroke(outlinePoints);
+    }
+
+    livePath.setAttribute('d', pathData);
+
+    if (isDashedOrDotted) {
+        livePath.setAttribute('fill', 'none');
+        livePath.setAttribute('stroke', style.color);
+        livePath.setAttribute('stroke-width', style.size.toString());
+        livePath.setAttribute('stroke-dasharray', getDashArray(style.dash, style.size) || '');
+        livePath.setAttribute('stroke-linecap', 'round');
+        livePath.setAttribute('stroke-linejoin', 'round');
+    } else {
+        livePath.setAttribute('fill', style.color);
+        livePath.removeAttribute('stroke');
+        livePath.removeAttribute('stroke-width');
+        livePath.removeAttribute('stroke-dasharray');
+        livePath.removeAttribute('stroke-linecap');
+        livePath.removeAttribute('stroke-linejoin');
+    }
+}
+
+/** Helper function to draw a standard line through the raw input points.
+ * Optimized Version to use InkPoint directly */
+function getCenterLinePath(points: InkPoint[]): string {
+    if (!points || points.length === 0) return '';
+    
+    const start = points[0];
+    let d = `M ${start[0]} ${start[1]}`;
+    
+    for (let i = 1; i < points.length; i++) {
+        const pt = points[i];
+        d += ` L ${pt[0]} ${pt[1]}`;
+    }
+    
+    return d;
 }

--- a/src/ink-canvas/types.ts
+++ b/src/ink-canvas/types.ts
@@ -8,6 +8,9 @@ import { INK_STROKE_ZOOM_REFERENCE } from './stroke-zoom-scale';
 /** A single point captured during pen/stylus input: [x, y, pressure]. */
 export type InkPoint = [x: number, y: number, pressure: number];
 
+/** Stroke Line Style*/
+export type StrokeDashStyle = 'solid' | 'dashed' | 'dotted';
+
 /** Rendering options stored per-stroke so each stroke can have its own visual style. */
 export interface InkStrokeStyle {
 	/** Base diameter in canvas units. */
@@ -32,6 +35,8 @@ export interface InkStrokeStyle {
 	 * Drives mergeNearDuplicate scaling on re-render; streamline/smoothing are stored already scaled.
 	 */
 	captureZoom?: number;
+	/** Style of the Stroke */
+	dash?: StrokeDashStyle;
 }
 
 /** perfect-freehand options plus ink-canvas outline preprocessing fields. */
@@ -91,6 +96,7 @@ export const DEFAULT_STROKE_STYLE: InkStrokeStyle = {
 	streamline: 0.5,
 	simulatePressure: true,
 	color: 'currentColor',
+	dash: 'solid',
 };
 
 /** Convert an InkStrokeStyle to perfect-freehand StrokeOptions. */


### PR DESCRIPTION
I use Ink daily for my Uni notes and i always wished it had the possibility to change to color/thickness/pattern of a stroke. Now with the move away from tldraw i though i try my luck. 

In Short, this PR adds:
-Style Menu for Color/Thickness/Style on the bottom right
-13 Color Presets
-10 Size Presets
-Solid/Dashed/Dotted Stroke Presets

<img width="327" height="226" alt="grafik" src="https://github.com/user-attachments/assets/007af353-40d3-4ae5-abd1-ca5d7b78a0e8" />
<img width="327" height="226" alt="grafik" src="https://github.com/user-attachments/assets/922a1718-ca73-4edf-8903-24c25fa65b91" />
<img width="188" height="156" alt="grafik" src="https://github.com/user-attachments/assets/9c3ae676-4a55-4611-91f8-3137bb0bac92" />


## What changed

-Add: new Command to update the pattern of an existing Stroke
-Add: StrokeDashStyle to InkStrokeStyle
-Add: Style Menu to drawing-editor and writing-editor
-Update: draw-tool so a line is correctly styled when the user is currently drawing
-Update: tooltip-button to expose the style attribute
-Update: stroke-store to make notify public
-Fix: command->UpdateStrokesStyleCommand apply create new array and new stroke reference to fix that changes to selected strokes would only apply once the stroke is deselected
-Update: ink-svg-canvas->strokePathPropsAreEqual check individual style properties


## Validation

- Manually tested with and without synced notes on PC and a Samsung Galaxy Tab S7 FE
- `npm run test:unit -- --runInBand` — 57 suites and 567 tests passed
- `npm run build` — TypeScript and production esbuild completed successfully.

Related to https://github.com/daledesilva/obsidian_ink/issues/53.